### PR TITLE
Ask phoneNumber permissions according to Android os version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Release Notes
 
 ### Next
+ * fix: Use API-specific permissions to get phone number (https://github.com/react-native-community/react-native-device-info/pull/269)
  * fix: Add OnePlus A6010 to devicesWithNothc list (https://github.com/react-native-community/react-native-device-info/pull/604)
  * fix: use reactContext vs getApplicationContext() (https://github.com/react-native-community/react-native-device-info/pull/382)
 

--- a/README.md
+++ b/README.md
@@ -639,7 +639,7 @@ Gets the device phone number.
 ```js
 const phoneNumber = DeviceInfo.getPhoneNumber();
 
-// Android: ?
+// Android: null return: no permission, empty string: unprogrammed or empty SIM1, e.g. "+15555215558": normal return value
 ```
 
 **Android Permissions**

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -383,8 +383,8 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
 
     if (reactContext != null &&
          (reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED ||
-           (Build.VERSION.SDK_INT >= 23 && reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_SMS) == PackageManager.PERMISSION_GRANTED) ||
-           (Build.VERSION.SDK_INT >= 26 && reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_NUMBERS) == PackageManager.PERMISSION_GRANTED))) {
+           (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_SMS) == PackageManager.PERMISSION_GRANTED) ||
+           (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_NUMBERS) == PackageManager.PERMISSION_GRANTED))) {
       TelephonyManager telMgr = (TelephonyManager) this.reactContext.getApplicationContext().getSystemService(Context.TELEPHONY_SERVICE);
       constants.put("phoneNumber", telMgr.getLine1Number());
     } else {

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -381,6 +381,16 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     constants.put("freeDiskStorage", this.getFreeDiskStorage());
     constants.put("installReferrer", this.getInstallReferrer());
 
+    if (reactContext != null &&
+         (reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED ||
+           (Build.VERSION.SDK_INT >= 23 && reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_SMS) == PackageManager.PERMISSION_GRANTED) ||
+           (Build.VERSION.SDK_INT >= 26 && reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_NUMBERS) == PackageManager.PERMISSION_GRANTED))) {
+      TelephonyManager telMgr = (TelephonyManager) this.reactContext.getApplicationContext().getSystemService(Context.TELEPHONY_SERVICE);
+      constants.put("phoneNumber", telMgr.getLine1Number());
+    } else {
+      constants.put("phoneNumber", null);
+    }
+
     Runtime rt = Runtime.getRuntime();
     constants.put("maxMemory", rt.maxMemory());
     ActivityManager actMgr = (ActivityManager) this.reactContext.getSystemService(Context.ACTIVITY_SERVICE);
@@ -393,42 +403,6 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     } else {
       constants.put("supportedABIs", new String[]{ Build.CPU_ABI });
     }
-    constants.put("phoneNumber", getPhoneNumber());
     return constants;
-  }
-
-  private @Nullable String getPhoneNumber() {
-    int apiLevel = Build.VERSION.SDK_INT;
-    String phoneNumber = null;
-    boolean hasPermission = false;
-
-    try {
-      if (getCurrentActivity() != null) {
-        // ApiLevel <= Lollipop
-        if (apiLevel <= 22) {
-          hasPermission = this.reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED;
-        }
-        // ApiLevel <= Nougat
-        else if (apiLevel <= 25) {
-          hasPermission = this.reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED ||
-                  this.reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_SMS) == PackageManager.PERMISSION_GRANTED;
-        }
-        // ApiLevel >= Oreo
-        else {
-          hasPermission = this.reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED ||
-                  this.reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_SMS) == PackageManager.PERMISSION_GRANTED ||
-                  this.reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_NUMBERS) == PackageManager.PERMISSION_GRANTED;
-        }
-    }
-
-    if (hasPermission) {
-        TelephonyManager telMgr = (TelephonyManager) this.reactContext.getApplicationContext().getSystemService(Context.TELEPHONY_SERVICE);
-        phoneNumber = telMgr.getLine1Number();
-      }
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-
-    return phoneNumber;
   }
 }

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -402,27 +402,31 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     String phoneNumber = null;
     boolean hasPermission = false;
 
-    if (getCurrentActivity() != null) {
-      // ApiLevel <= Lollipop
-      if (apiLevel <= 22) {
-        hasPermission = this.reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED;
-      }
-      // ApiLevel <= Nougat
-      else if (apiLevel <= 25) {
-        hasPermission = this.reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED ||
-                this.reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_SMS) == PackageManager.PERMISSION_GRANTED;
-      }
-      // ApiLevel >= Oreo
-      else {
-        hasPermission = this.reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED ||
-                this.reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_SMS) == PackageManager.PERMISSION_GRANTED ||
-                this.reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_NUMBERS) == PackageManager.PERMISSION_GRANTED;
-      }
+    try {
+      if (getCurrentActivity() != null) {
+        // ApiLevel <= Lollipop
+        if (apiLevel <= 22) {
+          hasPermission = this.reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED;
+        }
+        // ApiLevel <= Nougat
+        else if (apiLevel <= 25) {
+          hasPermission = this.reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED ||
+                  this.reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_SMS) == PackageManager.PERMISSION_GRANTED;
+        }
+        // ApiLevel >= Oreo
+        else {
+          hasPermission = this.reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED ||
+                  this.reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_SMS) == PackageManager.PERMISSION_GRANTED ||
+                  this.reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_NUMBERS) == PackageManager.PERMISSION_GRANTED;
+        }
     }
 
     if (hasPermission) {
-      TelephonyManager telMgr = (TelephonyManager) this.reactContext.getApplicationContext().getSystemService(Context.TELEPHONY_SERVICE);
-      phoneNumber = telMgr.getLine1Number();
+        TelephonyManager telMgr = (TelephonyManager) this.reactContext.getApplicationContext().getSystemService(Context.TELEPHONY_SERVICE);
+        phoneNumber = telMgr.getLine1Number();
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
     }
 
     return phoneNumber;


### PR DESCRIPTION
Ask relevant permissions according to Android os version. Issue: #268 
Relevant links for Android source code, each page shows what permissions getLine1Number method requires.

[Lollipop - TelephoneManager source code](https://android.googlesource.com/platform/frameworks/base.git/+/lollipop-release/telephony/java/android/telephony/TelephonyManager.java)
[Marshmallow - TelephoneManager source code](https://android.googlesource.com/platform/frameworks/base.git/+/marshmallow-release/telephony/java/android/telephony/TelephonyManager.java)
[Nougat - TelephoneManager source code](https://android.googlesource.com/platform/frameworks/base.git/+/nougat-release/telephony/java/android/telephony/TelephonyManager.java)
[Lollipop - TelephoneManager source code](https://android.googlesource.com/platform/frameworks/base.git/+/oreo-release/telephony/java/android/telephony/TelephonyManager.java) 

