### PR TITLE
Fix Android Crashes in Versions <= 4.2.2 (Api 18) 

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -127,25 +127,23 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public Integer getTotalDiskCapacity() {
-    try {
-      StatFs root = new StatFs(Environment.getRootDirectory().getAbsolutePath());
+  public long getTotalDiskCapacity() {
+    StatFs root = new StatFs(Environment.getRootDirectory().getAbsolutePath());
+    if (android.os.Build.VERSION.SDK_INT <= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1){
       return root.getBlockCount() * root.getBlockSize();
-    } catch (Exception e) {
-      e.printStackTrace();
+    } else{
+      return root.getBlockCountLong() * root.getBlockSizeLong();
     }
-    return null;
   }
 
   @ReactMethod
-  public Integer getFreeDiskStorage() {
-    try {
-      StatFs external = new StatFs(Environment.getExternalStorageDirectory().getAbsolutePath());
+  public long getTotalDiskCapacity() {
+    StatFs external = new StatFs(Environment.getExternalStorageDirectory().getAbsolutePath());
+    if (android.os.Build.VERSION.SDK_INT <= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1){
       return external.getAvailableBlocks() * external.getBlockSize();
-    } catch (Exception e) {
-      e.printStackTrace();
+    } else{
+      return external.getAvailableBlocksLong() * external.getBlockSizeLong();
     }
-    return null;
   }
 
   @Override


### PR DESCRIPTION
## Description

The Android Version 4.2.2 or fewer was getting crash when importing the react-native-device-info.

The uses of method *getTotalDiskCapacity* and *getFreeDiskStorage* was getting crash because was using the method *getAvailableBlocksLong* which was added only in Android 4.3 

## StackTrace

```
Fatal Exception: com.facebook.react.common.JavascriptException: C++ Exception in 'NativeModules': java.lang.NoSuchMethodError: android.os.StatFs.getBlockCountLong
```

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [X] I have implemented an verification of Android Version to get the correct method compatilble
