### PR TITLE
Update the getDeviceLocale for iOS to match Android result

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ Gets the device locale.
 ```js
 const deviceLocale = DeviceInfo.getDeviceLocale();
 
-// iOS: "en"
+// iOS: "en-US"
 // Android: "en-US"
 // Windows: ?
 ```

--- a/RNDeviceInfo/RNDeviceInfo.m
+++ b/RNDeviceInfo/RNDeviceInfo.m
@@ -179,7 +179,7 @@ RCT_EXPORT_MODULE(RNDeviceInfo)
 
 - (NSString*) deviceLocale
 {
-    NSString *language = [[NSLocale preferredLanguages] objectAtIndex:0];
+    NSString *language = [[NSLocale currentLocale] localeIdentifier];
     return language;
 }
 
@@ -233,7 +233,7 @@ RCT_EXPORT_MODULE(RNDeviceInfo)
 }
 
 - (NSDictionary *) getStorageDictionary {
-	NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);  
+	NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
     return [[NSFileManager defaultManager] attributesOfFileSystemForPath:[paths lastObject] error: nil];
 }
 
@@ -251,7 +251,7 @@ RCT_EXPORT_MODULE(RNDeviceInfo)
 - (uint64_t) freeDiskStorage {
     uint64_t freeSpace = 0;
     NSDictionary *storage = [self getStorageDictionary];
-    
+
     if (storage) {
         NSNumber *freeFileSystemSizeInBytes = [storage objectForKey: NSFileSystemFreeSize];
         freeSpace = [freeFileSystemSizeInBytes unsignedLongLongValue];


### PR DESCRIPTION
## Description

This PR updates the `getDeviceLocale` function to return the locale instead of the preferred language for iOS. This will update the method to match the Android behaviour.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`.
* [ ] I mentionned this change in `CHANGELOG.md`.
