### PR TITLE
Added support for `getUsedMemory` to get the app memory usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### next
 
+* Add `getUsedMemory` (https://github.com/rebeccahughes/react-native-device-info/pull/356)
+
 ### 0.17.4
 
 * Fix `getMACAddress` for Android > 6 (https://github.com/rebeccahughes/react-native-device-info/pull/349)

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ var DeviceInfo = require('react-native-device-info');
 | [getTotalDiskCapacity()](#gettotaldiskcapacity)   | `number`            |  ✅  |   ✅    |   ❌    | 0.15.0 |
 | [getTotalMemory()](#gettotalmemory)               | `number`            |  ✅  |   ✅    |   ❌    | 0.14.0 |
 | [getUniqueID()](#getuniqueid)                     | `string`            |  ✅  |   ✅    |   ✅    | ?      |
+| [getUsedMemory()](#getusedmemory)                 | `Promise<number>`   |  ✅  |   ✅    |   ❌    | 0.18.0 |
 | [getUserAgent()](#getuseragent)                   | `string`            |  ✅  |   ✅    |   ❌    | 0.7.0  |
 | [getVersion()](#getversion)                       | `string`            |  ✅  |   ✅    |   ✅    | ?      |
 | [is24Hour()](#is24hour)                           | `boolean`           |  ✅  |   ✅    |   ✅    | 0.13.0 |
@@ -706,6 +707,21 @@ const uniqueId = DeviceInfo.getUniqueID();
 
 > * iOS: This is [`IDFV`](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor) so it will change if all apps from the current apps vendor have been previously uninstalled.
 > * android: Prior to Oreo, this id ([ANDROID_ID](https://developer.android.com/reference/android/provider/Settings.Secure.html#ANDROID_ID)) will always be the same once you set up your phone.
+
+---
+
+### getUsedMemory()
+
+Gets the apps memory usage, in bytes.
+
+**Examples**
+
+```js
+DeviceInfo.getUsedMemory().then((usedMemory) => {
+  // 173555712
+});
+```
+
 ---
 
 ### getUserAgent()

--- a/RNDeviceInfo/RNDeviceInfo.m
+++ b/RNDeviceInfo/RNDeviceInfo.m
@@ -11,6 +11,7 @@
 #if !(TARGET_OS_TV)
 #import <LocalAuthentication/LocalAuthentication.h>
 #endif
+#import <mach/mach.h>
 
 @interface RNDeviceInfo()
 @property (nonatomic) bool isEmulator;
@@ -302,6 +303,22 @@ RCT_EXPORT_METHOD(isPinOrFingerprintSet:(RCTResponseSenderBlock)callback)
     BOOL isPinOrFingerprintSet = ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:nil]);
   #endif
     callback(@[[NSNumber numberWithBool:isPinOrFingerprintSet]]);
+}
+
+RCT_EXPORT_METHOD(getUsedMemory:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+    struct task_basic_info info;
+    mach_msg_type_number_t size = sizeof(info);
+    kern_return_t kerr = task_info(mach_task_self(),
+                                   TASK_BASIC_INFO,
+                                   (task_info_t)&info,
+                                   &size);
+    if (kerr != KERN_SUCCESS) {
+      reject(@"fetch_error", @"task_info failed", nil);
+      return;
+    }
+
+    resolve(@((unsigned long)info.resident_size));
 }
 
 @end

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -195,6 +195,13 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     return null;
   }
 
+  @ReactMethod
+  public void getUsedMemory(Promise p) {
+    Runtime rt = Runtime.getRuntime();
+    long usedMemory = rt.totalMemory() - rt.freeMemory();
+    p.resolve((int)usedMemory);
+  }
+
   @Override
   public @Nullable
   Map<String, Object> getConstants() {

--- a/deviceinfo.d.ts
+++ b/deviceinfo.d.ts
@@ -38,4 +38,4 @@ export function getTotalMemory(): number;
 export function getMaxMemory(): number;
 export function getTotalDiskCapacity(): number;
 export function getFreeDiskStorage(): number;
-export function getUsedMemory(): number;
+export function getUsedMemory(): Promise<number>;

--- a/deviceinfo.d.ts
+++ b/deviceinfo.d.ts
@@ -38,3 +38,4 @@ export function getTotalMemory(): number;
 export function getMaxMemory(): number;
 export function getTotalDiskCapacity(): number;
 export function getFreeDiskStorage(): number;
+export function getUsedMemory(): number;

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -115,4 +115,7 @@ module.exports = {
   getFreeDiskStorage: function() {
     return RNDeviceInfo.freeDiskStorage;
   },
+  getUsedMemory: function() {
+    return RNDeviceInfo.getUsedMemory();
+  },
 };

--- a/deviceinfo.js.flow
+++ b/deviceinfo.js.flow
@@ -38,4 +38,5 @@ declare module.exports: {
   getMaxMemory: () => number,
   getTotalDiskCapacity: () => number,
   getFreeDiskStorage: () => number,
+  getUsedMemory: () => number
 };

--- a/deviceinfo.js.flow
+++ b/deviceinfo.js.flow
@@ -38,5 +38,5 @@ declare module.exports: {
   getMaxMemory: () => number,
   getTotalDiskCapacity: () => number,
   getFreeDiskStorage: () => number,
-  getUsedMemory: () => number
+  getUsedMemory: () => Promise<number>
 };

--- a/web/index.js
+++ b/web/index.js
@@ -37,4 +37,5 @@ module.exports = {
   maxMemory: 0,
   totalDiskCapacity: 0,
   freeDiskStorage: 0,
+  getUsedMemory: () => Promise.resolve(0),
 };


### PR DESCRIPTION
## Description

Added `getUsedMemory()` that allows for getting the current memory usage of the App. This feature returns the same value as you would otherwise see in the react-native Perf Monitor overlay.

This feature has been battle tested on both Android & iOS in our App for about 5 months now. Works like a charm, no side effects, never saw any problems.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

* [X] I have tested this on a device/simulator for each compatible OS
* [X] I added the documentation in `README.md`.
* [X] I mentioned this change in `CHANGELOG.md`.
