### PR TITLE
Add getBundleHost

### DIFF
--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -115,6 +115,9 @@ module.exports = {
   getTotalDiskCapacity: function() {
     return RNDeviceInfo.totalDiskCapacity;
   },
+  getBundleHost: function() {
+    return RNDeviceInfo.bundleHost;
+  },
   getFreeDiskStorage: function() {
     return RNDeviceInfo.freeDiskStorage;
   },

--- a/ios/RNDeviceInfo/RNDeviceInfo.h
+++ b/ios/RNDeviceInfo/RNDeviceInfo.h
@@ -15,6 +15,8 @@
 #import "RCTBridgeModule.h"
 #endif
 
+#import <React/RCTBridge.h>
+
 @interface RNDeviceInfo : NSObject <RCTBridgeModule>
 
 @end

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -8,6 +8,8 @@
 
 #import "RNDeviceInfo.h"
 #import "DeviceUID.h"
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTBridge.h>
 #if !(TARGET_OS_TV)
 #import <LocalAuthentication/LocalAuthentication.h>
 #endif
@@ -22,6 +24,7 @@
 
 @implementation RNDeviceInfo
 
+@synthesize bridge = _bridge;
 @synthesize isEmulator;
 
 RCT_EXPORT_MODULE(RNDeviceInfo)
@@ -259,6 +262,10 @@ RCT_EXPORT_MODULE(RNDeviceInfo)
     return freeSpace;
 }
 
+- (NSString *) bundleHost {
+    return self.bridge.bundleURL.host;
+}
+
 - (NSDictionary *)constantsToExport
 {
     UIDevice *currentDevice = [UIDevice currentDevice];
@@ -290,6 +297,7 @@ RCT_EXPORT_MODULE(RNDeviceInfo)
              @"totalMemory": @(self.totalMemory),
              @"totalDiskCapacity": @(self.totalDiskCapacity),
              @"freeDiskStorage": @(self.freeDiskStorage),
+             @"bundleHost": self.bundleHost ?: [NSNull null],
              };
 }
 


### PR DESCRIPTION
I'm posting this in a very incomplete state to understand if this is something you're interested in adding to react-native-device-info. I'll flesh it out fully with docs and Android support if you're interested.

## Description

Added `getBundleHost()` that allows you to get the host that the bundler the react native shell is connected to.  When running in dev mode/using metro remotely (rather than a baked-in
  pre-compiled bundle) you can use this to have your app automatically
  connect to an API server on your dev machine.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [ ] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`.
* [ ] I mentionned this change in `CHANGELOG.md`.