### PR TITLE
Use RCTSharedApplication instead of [UIApplication sharedApplication]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Release Notes
 
 ### 1.4.2:
+ * fix: Use `RCTSharedApplication` so compile works for ios app extensions (https://github.com/react-native-community/react-native-device-info/pull/408)
  * chore: Add 3rd generation iPad pro to device/model list (https://github.com/react-native-community/react-native-device-info/pull/618)
  * feat: Support `getUserAgent()` on old androids (API level <= 16) (https://github.com/react-native-community/react-native-device-info/pull/545)
  * chore: Add Huweai INE-LX1 to devices with notch (https://github.com/react-native-community/react-native-device-info/pull/624)
@@ -119,10 +120,6 @@
 ### 0.22.0
 
 * Add support for `getIpAddress` and `getMacAddress` on iOS (https://github.com/react-native-community/react-native-device-info/commit/41735bd0b2efe1f626afc066604f27073acb9d4c)
-
-* Use `RCTSharedApplication` which hides [UIApplication sharedApplication] so
-  iOS app extensions can include the library through CocoaPods without
-  compilation errors.
 
 ### 0.21.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,10 @@
 
 * Add support for `getIpAddress` and `getMacAddress` on iOS (https://github.com/react-native-community/react-native-device-info/commit/41735bd0b2efe1f626afc066604f27073acb9d4c)
 
+* Use `RCTSharedApplication` which hides [UIApplication sharedApplication] so
+  iOS app extensions can include the library through CocoaPods without
+  compilation errors.
+
 ### 0.21.5
 
 * Rolled back the Pod change made in 0.21.1

--- a/README.md
+++ b/README.md
@@ -478,6 +478,8 @@ Gets the device font scale.
 The font scale is the ratio of the current system font to the "normal" font size, so if normal text is 10pt and the system font is currently 15pt, the font scale would be 1.5
 This can be used to determine if accessability settings has been changed for the device; you may want to re-layout certain views if the font scale is significantly larger ( > 2.0 )
 
+In iOS App Extensions this call always returns 1.0, see #625.
+
 **Examples**
 
 ```js

--- a/ios/RNDeviceInfo/RNDeviceInfo.h
+++ b/ios/RNDeviceInfo/RNDeviceInfo.h
@@ -8,16 +8,9 @@
 
 #import <UIKit/UIKit.h>
 #import <sys/utsname.h>
-
-#if __has_include(<React/RCTAssert.h>)
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventEmitter.h>
 #import <React/RCTLog.h>
-#else
-#import "RCTBridgeModule.h"
-#import "RCTEventEmitter.h"
-#import "RCTLog.h"
-#endif
 
 @interface RNDeviceInfo : RCTEventEmitter <RCTBridgeModule>
 

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -9,14 +9,9 @@
 #include <ifaddrs.h>
 #include <arpa/inet.h>
 #import <mach-o/arch.h>
+#import <React/RCTUtils.h>
 #import "RNDeviceInfo.h"
 #import "DeviceUID.h"
-
-#if __has_include(<React/RCTAssert.h>)
-#import <React/RCTUtils.h>
-#else
-#import "RCTUtils.h"
-#endif
 
 #if !(TARGET_OS_TV)
 #import <LocalAuthentication/LocalAuthentication.h>

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -11,6 +11,13 @@
 #import <mach-o/arch.h>
 #import "RNDeviceInfo.h"
 #import "DeviceUID.h"
+
+#if __has_include(<React/RCTAssert.h>)
+#import <React/RCTUtils.h>
+#else
+#import "RCTUtils.h"
+#endif
+
 #if !(TARGET_OS_TV)
 #import <LocalAuthentication/LocalAuthentication.h>
 #endif
@@ -277,20 +284,25 @@ RCT_EXPORT_MODULE(RNDeviceInfo);
 - (NSNumber*) fontScale
 {
   float fontScale = 1.0;
-  NSString *contentSize = [UIApplication sharedApplication].preferredContentSizeCategory;
+  UIApplication *application = RCTSharedApplication();
 
-  if ([contentSize isEqual: @"UICTContentSizeCategoryXS"]) fontScale = 0.82;
-  else if ([contentSize isEqual: @"UICTContentSizeCategoryS"]) fontScale = 0.88;
-  else if ([contentSize isEqual: @"UICTContentSizeCategoryM"]) fontScale = 0.95;
-  else if ([contentSize isEqual: @"UICTContentSizeCategoryL"]) fontScale = 1.0;
-  else if ([contentSize isEqual: @"UICTContentSizeCategoryXL"]) fontScale = 1.12;
-  else if ([contentSize isEqual: @"UICTContentSizeCategoryXXL"]) fontScale = 1.23;
-  else if ([contentSize isEqual: @"UICTContentSizeCategoryXXXL"]) fontScale = 1.35;
-  else if ([contentSize isEqual: @"UICTContentSizeCategoryAccessibilityM"]) fontScale = 1.64;
-  else if ([contentSize isEqual: @"UICTContentSizeCategoryAccessibilityL"]) fontScale = 1.95;
-  else if ([contentSize isEqual: @"UICTContentSizeCategoryAccessibilityXL"]) fontScale = 2.35;
-  else if ([contentSize isEqual: @"UICTContentSizeCategoryAccessibilityXXL"]) fontScale = 2.76;
-  else if ([contentSize isEqual: @"UICTContentSizeCategoryAccessibilityXXXL"]) fontScale = 3.12;
+  // Shared application is unavailable in an app extension.
+  if (application) {
+    NSString *contentSize = application.preferredContentSizeCategory;
+
+    if ([contentSize isEqual: @"UICTContentSizeCategoryXS"]) fontScale = 0.82;
+    else if ([contentSize isEqual: @"UICTContentSizeCategoryS"]) fontScale = 0.88;
+    else if ([contentSize isEqual: @"UICTContentSizeCategoryM"]) fontScale = 0.95;
+    else if ([contentSize isEqual: @"UICTContentSizeCategoryL"]) fontScale = 1.0;
+    else if ([contentSize isEqual: @"UICTContentSizeCategoryXL"]) fontScale = 1.12;
+    else if ([contentSize isEqual: @"UICTContentSizeCategoryXXL"]) fontScale = 1.23;
+    else if ([contentSize isEqual: @"UICTContentSizeCategoryXXXL"]) fontScale = 1.35;
+    else if ([contentSize isEqual: @"UICTContentSizeCategoryAccessibilityM"]) fontScale = 1.64;
+    else if ([contentSize isEqual: @"UICTContentSizeCategoryAccessibilityL"]) fontScale = 1.95;
+    else if ([contentSize isEqual: @"UICTContentSizeCategoryAccessibilityXL"]) fontScale = 2.35;
+    else if ([contentSize isEqual: @"UICTContentSizeCategoryAccessibilityXXL"]) fontScale = 2.76;
+    else if ([contentSize isEqual: @"UICTContentSizeCategoryAccessibilityXXXL"]) fontScale = 3.12;
+  }
 
   return [NSNumber numberWithFloat: fontScale];
 }


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes #347.

Calling `[UIApplication sharedApplication]` [is unsafe in an app extension][0]. This is hidden by `RCTSharedApplication` which lets app extensions include this library through CocoaPods [without compilation errors][1].

[0]: https://developer.apple.com/library/content/documentation/General/Conceptual/ExtensibilityPG/ExtensionOverview.html#//apple_ref/doc/uid/TP40014214-CH2-SW6
[1]: https://github.com/CocoaPods/CocoaPods/pull/3048

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    N/A     |
| Windows |    N/A     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`.
  
  >I don’t think this is necessary for this PR.
* [x] I mentioned this change in `CHANGELOG.md`.
