### PR TITLE
Creates getPhoneNumber getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## Release Notes
 
-### next
-
 ### 0.21.5
 
 * Rolled back the Pod change made in 0.21.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Release Notes
 
+## Next
+
+* `getPhoneNumber` now returns a promise. Fixes https://github.com/rebeccahughes/react-native-device-info/issues/416
+
 ### 0.21.5
 
 * Rolled back the Pod change made in 0.21.1

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ var DeviceInfo = require('react-native-device-info');
 | [getManufacturer()](#getmanufacturer)             | `string`            |  ✅  |   ✅    |   ✅    | ?      |
 | [getMaxMemory()](#getmaxmemory)                   | `number`            |  ❌  |   ✅    |   ✅    | 0.14.0 |
 | [getModel()](#getmodel)                           | `string`            |  ✅  |   ✅    |   ✅    | ?      |
-| [getPhoneNumber()](#getphonenumber)               | `string`            |  ❌  |   ✅    |   ❌    | 0.12.0 |
+| [getPhoneNumber()](#getphonenumber)               | `Promise<string>`   |  ❌  |   ✅    |   ❌    | 0.12.0 |
 | [getReadableVersion()](#getreadableversion)       | `string`            |  ✅  |   ✅    |   ✅    | ?      |
 | [getSerialNumber()](#getserialnumber)             | `string`            |  ❌  |   ✅    |   ❌    | 0.12.0 |
 | [getSystemName()](#getsystemname)                 | `string`            |  ✅  |   ✅    |   ✅    | ?      |
@@ -600,9 +600,11 @@ Gets the device phone number.
 **Examples**
 
 ```js
-const phoneNumber = DeviceInfo.getPhoneNumber();
-
-// Android: ?
+DeviceInfo.getPhoneNumber().then(phoneNumber => {
+    // iOS: null
+    // Android: ?
+    // Windows: null
+});
 ```
 
 **Android Permissions**

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -208,6 +208,20 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     p.resolve(batteryLevel);
   }
 
+  @ReactMethod
+  public void getPhoneNumber(Promise p) {
+    if (this.reactContext != null &&
+            (this.reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED ||
+                    this.reactContext.checkCallingOrSelfPermission(Manifest.permission.READ_SMS) == PackageManager.PERMISSION_GRANTED ||
+                    this.reactContext.checkCallingOrSelfPermission("android.permission.READ_PHONE_NUMBERS") == PackageManager.PERMISSION_GRANTED)) {
+      TelephonyManager telMgr = (TelephonyManager) this.reactContext.getApplicationContext().getSystemService(Context.TELEPHONY_SERVICE);
+      p.resolve(telMgr.getLine1Number());
+    }
+    else {
+      p.resolve(null);
+    }
+  }
+
   public String getInstallReferrer() {
     SharedPreferences sharedPref = getReactApplicationContext().getSharedPreferences("react-native-device-info", Context.MODE_PRIVATE);
     return sharedPref.getString("installReferrer", null);
@@ -287,13 +301,6 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     constants.put("isTablet", this.isTablet());
     constants.put("fontScale", this.fontScale());
     constants.put("is24Hour", this.is24Hour());
-    if (getCurrentActivity() != null &&
-        (getCurrentActivity().checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED ||
-            getCurrentActivity().checkCallingOrSelfPermission(Manifest.permission.READ_SMS) == PackageManager.PERMISSION_GRANTED ||
-            getCurrentActivity().checkCallingOrSelfPermission("android.permission.READ_PHONE_NUMBERS") == PackageManager.PERMISSION_GRANTED)) {
-      TelephonyManager telMgr = (TelephonyManager) this.reactContext.getApplicationContext().getSystemService(Context.TELEPHONY_SERVICE);
-      constants.put("phoneNumber", telMgr.getLine1Number());
-    }
     constants.put("carrier", this.getCarrier());
     constants.put("totalDiskCapacity", this.getTotalDiskCapacity());
     constants.put("freeDiskStorage", this.getFreeDiskStorage());

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -101,7 +101,12 @@ module.exports = {
     return RNDeviceInfo.lastUpdateTime;
   },
   getPhoneNumber: function() {
-    return RNDeviceInfo.phoneNumber;
+      if (Platform.OS === 'ios') {
+        return Promise.resolve(null)
+      }
+      else {
+          return RNDeviceInfo.getPhoneNumber();
+      }
   },
   getCarrier: function() {
     return RNDeviceInfo.carrier;


### PR DESCRIPTION
## Description

Fixed issue https://github.com/rebeccahughes/react-native-device-info/issues/416

NOTE: This introduces a breaking change. `getPhoneNumber` now returns a promise rather than a string. 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅    |
| Windows |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`.
* [x] I mentionned this change in `CHANGELOG.md`.
