### PR TITLE
feat: add battery monitoring and detailed power state getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Release Notes
 
+### 1.3.0
+ * feat: add battery monitoring and detailed power state getter (https://github.com/react-native-community/react-native-device-info/pull/436)
+
 ### 1.2.0
  * feat: Support 'dom' Platform.OS for react-native-dom (https://github.com/react-native-community/react-native-device-info/pull/406)
  * feat: Add support for jest snapshot testing (https://github.com/react-native-community/react-native-device-info/pull/375)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## Release Notes
 
-### 1.3.0
+### 1.4.0
  * feat: add battery monitoring and detailed power state getter (https://github.com/react-native-community/react-native-device-info/pull/436)
+
+### 1.3.0
  * feat: Add support for preferred languages function (https://github.com/react-native-community/react-native-device-info/pull/610)
 
 ### 1.2.0

--- a/README.md
+++ b/README.md
@@ -673,7 +673,7 @@ const phoneNumber = DeviceInfo.getPhoneNumber();
 ### getPowerState()
 
 Gets the power state of the device including the battery level, whether it is plugged in, and if the system is currently operating in low power mode.
-Displays a warning on iOS if battery monitoring not enabled, or if attempted on an emulator (where montioring is not possible)
+Displays a warning on iOS if battery monitoring not enabled, or if attempted on an emulator (where monitoring is not possible)
 
 **Examples**
 

--- a/README.md
+++ b/README.md
@@ -656,6 +656,7 @@ const phoneNumber = DeviceInfo.getPhoneNumber();
 ### getPowerState()
 
 Gets the power state of the device including the battery level, whether it is plugged in, and if the system is currently operating in low power mode.
+Displays a warning on iOS if battery monitoring not enabled, or if attempted on an emulator (where montioring is not possible)
 
 **Examples**
 

--- a/README.md
+++ b/README.md
@@ -652,6 +652,24 @@ const phoneNumber = DeviceInfo.getPhoneNumber();
 
 ---
 
+### getPowerState()
+
+Gets the power state of the device including the battery level, whether it is plugged in, and if the system is currently operating in low power mode.
+
+**Examples**
+
+```js
+DeviceInfo.getPowerState().then(state => {
+  // {
+  //   batteryLevel: 0.759999,
+  //   batteryState: 'unplugged',
+  //   lowPowerMode: false,
+  // }
+});
+```
+
+---
+
 ### getReadableVersion()
 
 Gets the application human readable version.
@@ -964,6 +982,50 @@ Returns a list of supported processor architecture version
 DeviceInfo.supportedABIs(); // [ "arm64 v8", "Intel x86-64h Haswell", "arm64-v8a", "armeabi-v7a", "armeabi" ]
 ```
 
+## Events
+
+Currently iOS-only.
+
+### batteryLevelDidChange
+
+Fired when the battery level changes; sent no more frequently than once per minute.
+
+**Examples**
+
+```js
+deviceInfoEmitter.addListener('batteryLevelDidChange', level => {
+  // 0.759999
+});
+```
+
+---
+
+### batteryLevelIsLow
+
+Fired when the battery drops below 20%.
+
+**Examples**
+
+```js
+deviceInfoEmitter.addListener('batteryLevelIsLow', level => {
+  // 0.19
+});
+```
+
+---
+
+### powerStateDidChange
+
+Fired when the battery state changes, for example when the device enters charging mode or is unplugged.
+
+**Examples**
+
+```js
+deviceInfoEmitter.addListener('powerStateDidChange', { batteryState } => {
+  // 'charging'
+});
+```
+
 ## Troubleshooting
 
 When installing or using `react-native-device-info`, you may encounter the following problems:
@@ -1000,9 +1062,9 @@ Seems to be a bug caused by `react-native link`. You can manually delete `libRND
   <summary>[ios] - [NetworkInfo] Descriptors query returned error: Error Domain=NSCocoaErrorDomain Code=4099
  “The connection to service named com.apple.commcenter.coretelephony.xpc was invalidated.”</summary>
 
-This is a system level log that may be turned off by executing: 
-```xcrun simctl spawn booted log config --mode "level:off"  --subsystem com.apple.CoreTelephony```. 
-To undo the command, you can execute: 
+This is a system level log that may be turned off by executing:
+```xcrun simctl spawn booted log config --mode "level:off"  --subsystem com.apple.CoreTelephony```.
+To undo the command, you can execute:
 ```xcrun simctl spawn booted log config --mode "level:info"  --subsystem com.apple.CoreTelephony```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ import DeviceInfo from 'react-native-device-info';
 | [getVersion()](#getversion)                       | `string`            |  ✅  |   ✅    |   ✅    | ?      |
 | [is24Hour()](#is24hour)                           | `boolean`           |  ✅  |   ✅    |   ✅    | 0.13.0 |
 | [isAirPlaneMode()](#isairplanemode)               | `Promise<boolean>`  |  ❌  |   ✅    |   ❌    | 0.25.0 |
-| [isBatteryCharging()](#isbatterycharging)         | `Promise<boolean>`  |  ❌  |   ✅    |   ❌    | 0.27.0 |
+| [isBatteryCharging()](#isbatterycharging)         | `Promise<boolean>`  |  ✅  |   ✅    |   ❌    | 0.27.0 |
 | [isEmulator()](#isemulator)                       | `boolean`           |  ✅  |   ✅    |   ✅    | ?      |
 | [isPinOrFingerprintSet()](#ispinorfingerprintset) | (callback)`boolean` |  ✅  |   ✅    |   ✅    | 0.10.1 |
 | [isTablet()](#istablet)                           | `boolean`           |  ✅  |   ✅    |   ✅    | ?      |

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ import DeviceInfo from 'react-native-device-info';
 | [getMaxMemory()](#getmaxmemory)                   | `number`            |  ❌  |   ✅    |   ✅    | 0.14.0 |
 | [getModel()](#getmodel)                           | `string`            |  ✅  |   ✅    |   ✅    | ?      |
 | [getPhoneNumber()](#getphonenumber)               | `string`            |  ❌  |   ✅    |   ❌    | 0.12.0 |
+| [getPowerState()](#getpowerstate)                 | `Promise<object>`   |  ✅  |   ❌    |   ❌    |        |
 | [getReadableVersion()](#getreadableversion)       | `string`            |  ✅  |   ✅    |   ✅    | ?      |
 | [getSerialNumber()](#getserialnumber)             | `string`            |  ❌  |   ✅    |   ❌    | 0.12.0 |
 | [getSystemName()](#getsystemname)                 | `string`            |  ✅  |   ✅    |   ✅    | ?      |
@@ -993,6 +994,9 @@ Fired when the battery level changes; sent no more frequently than once per minu
 **Examples**
 
 ```js
+import { NativeEventEmitter, NativeModules } from 'react-native'
+const deviceInfoEmitter = new NativeEventEmitter(NativeModules.RNDeviceInfo)
+
 deviceInfoEmitter.addListener('batteryLevelDidChange', level => {
   // 0.759999
 });
@@ -1007,6 +1011,9 @@ Fired when the battery drops below 20%.
 **Examples**
 
 ```js
+import { NativeEventEmitter, NativeModules } from 'react-native'
+const deviceInfoEmitter = new NativeEventEmitter(NativeModules.RNDeviceInfo)
+
 deviceInfoEmitter.addListener('batteryLevelIsLow', level => {
   // 0.19
 });
@@ -1021,6 +1028,9 @@ Fired when the battery state changes, for example when the device enters chargin
 **Examples**
 
 ```js
+import { NativeEventEmitter, NativeModules } from 'react-native'
+const deviceInfoEmitter = new NativeEventEmitter(NativeModules.RNDeviceInfo)
+
 deviceInfoEmitter.addListener('powerStateDidChange', { batteryState } => {
   // 'charging'
 });

--- a/default/index.js
+++ b/default/index.js
@@ -41,4 +41,5 @@ module.exports = {
   getBatteryLevel: () => Promise.resolve(0),
   isLandscape: false,
   deviceType: 'Unknown',
+  getPowerState: () => Promise.resolve({})
 };

--- a/deviceinfo.d.ts
+++ b/deviceinfo.d.ts
@@ -42,6 +42,7 @@ declare const _default: {
   getTotalDiskCapacity: () => number;
   getFreeDiskStorage: () => number;
   getBatteryLevel: () => Promise<number>;
+  getPowerState: () => Promise<object>;
   isBatteryCharging: () => Promise<boolean>;
   isLandscape: () => boolean;
   isAirPlaneMode: () => Promise<boolean>;

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -311,6 +311,9 @@ export default {
   getBatteryLevel: function() {
     return RNDeviceInfo.getBatteryLevel();
   },
+  getPowerState: function() {
+    return RNDeviceInfo.getPowerState();
+  },
   isBatteryCharging: function() {
     return RNDeviceInfo.isBatteryCharging();
   },

--- a/deviceinfo.js.flow
+++ b/deviceinfo.js.flow
@@ -43,6 +43,7 @@ declare module.exports: {
   getTotalDiskCapacity: () => number,
   getFreeDiskStorage: () => number,
   getBatteryLevel: () => Promise<number>,
+  getPowerState: () => Promise<object>,
   isBatteryCharging:() => Promise<boolean>,
   isLandscape: () => boolean,
   isAirPlaneMode: () => Promise<boolean>,

--- a/example/App.js
+++ b/example/App.js
@@ -75,6 +75,7 @@ export default class App extends Component<Props> {
       deviceJSON.deviceType = DeviceInfo.getDeviceType();
       deviceJSON.isPinOrFingerprintSet = 'unknown';
       deviceJSON.supportedABIs = DeviceInfo.supportedABIs();
+      deviceJSON.powerState = ios ? await DeviceInfo.getPowerState() : '';
     } catch (e) {
       console.log('Trouble getting device info ', e);
     }

--- a/example/ios/example/AppDelegate.m
+++ b/example/ios/example/AppDelegate.m
@@ -27,7 +27,8 @@
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
-  [UIDevice currentDevice].batteryMonitoringEnabled = true; return YES;
+  [UIDevice currentDevice].batteryMonitoringEnabled = true;
+  return YES;
 }
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge

--- a/ios/RNDeviceInfo/RNDeviceInfo.h
+++ b/ios/RNDeviceInfo/RNDeviceInfo.h
@@ -21,4 +21,7 @@
 
 @interface RNDeviceInfo : RCTEventEmitter <RCTBridgeModule>
 
+@property (nonatomic) bool isEmulator;
+@property (nonatomic) float lowBatteryThreshold;
+
 @end

--- a/ios/RNDeviceInfo/RNDeviceInfo.h
+++ b/ios/RNDeviceInfo/RNDeviceInfo.h
@@ -11,10 +11,12 @@
 
 #if __has_include(<React/RCTAssert.h>)
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 #else
 #import "RCTBridgeModule.h"
+#import "RCTEventEmitter.h"
 #endif
 
-@interface RNDeviceInfo : NSObject <RCTBridgeModule>
+@interface RNDeviceInfo : RCTEventEmitter <RCTBridgeModule>
 
 @end

--- a/ios/RNDeviceInfo/RNDeviceInfo.h
+++ b/ios/RNDeviceInfo/RNDeviceInfo.h
@@ -12,9 +12,11 @@
 #if __has_include(<React/RCTAssert.h>)
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventEmitter.h>
+#import <React/RCTLog.h>
 #else
 #import "RCTBridgeModule.h"
 #import "RCTEventEmitter.h"
+#import "RCTLog.h"
 #endif
 
 @interface RNDeviceInfo : RCTEventEmitter <RCTBridgeModule>

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -447,6 +447,12 @@ RCT_EXPORT_METHOD(getPowerState:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
     return resolve(self.powerState);
 }
 
+RCT_EXPORT_METHOD(isBatteryCharging:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+    BOOL isCharging = [self.powerState[@"batteryState"] isEqualToString: @"charging"];
+    resolve(@(isCharging));
+}
+
 - (void)dealloc
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self];

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -433,7 +433,7 @@ RCT_EXPORT_METHOD(isPinOrFingerprintSet:(RCTResponseSenderBlock)callback)
 
 - (NSDictionary *)powerState
 {
-#if RCT_DEV
+#if RCT_DEV && (!TARGET_IPHONE_SIMULATOR)
     if ([UIDevice currentDevice].isBatteryMonitoringEnabled != true) {
         RCTLogWarn(@"Battery monitoring is not enabled. "
                    "You need to enable monitoring with `[UIDevice currentDevice].batteryMonitoringEnabled = TRUE`");
@@ -441,7 +441,7 @@ RCT_EXPORT_METHOD(isPinOrFingerprintSet:(RCTResponseSenderBlock)callback)
 #endif
 #if RCT_DEV && (TARGET_OS_TV || TARGET_IPHONE_SIMULATOR)
     if ([UIDevice currentDevice].batteryState == UIDeviceBatteryStateUnknown) {
-        RCTLogWarn(@"Battery state is `unknown` which is normal for simulators and tvOS.");
+        RCTLogWarn(@"Battery state `unknown` and monitoring disabled, this is normal for simulators and tvOS.");
     }
 #endif
 

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -419,6 +419,12 @@ RCT_EXPORT_METHOD(isPinOrFingerprintSet:(RCTResponseSenderBlock)callback)
 
 - (NSDictionary *)powerState
 {
+#if RCT_DEV && !TARGET_OS_TV && !TARGET_IPHONE_SIMULATOR
+    if ([UIDevice currentDevice].batteryState == UIDeviceBatteryStateUnknown) {
+        RCTLogWarn(@"Battery state is `unknown` which could mean battery monitoring is disabled." +
+                    "You may need to enable monitoring with `[UIDevice currentDevice].batteryMonitoringEnabled = TRUE`");
+    }
+#endif
     return @{
 #if TARGET_OS_TV
              @"batteryLevel": @1,

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -421,8 +421,8 @@ RCT_EXPORT_METHOD(isPinOrFingerprintSet:(RCTResponseSenderBlock)callback)
 {
 #if RCT_DEV && !TARGET_OS_TV && !TARGET_IPHONE_SIMULATOR
     if ([UIDevice currentDevice].batteryState == UIDeviceBatteryStateUnknown) {
-        RCTLogWarn(@"Battery state is `unknown` which could mean battery monitoring is disabled." +
-                    "You may need to enable monitoring with `[UIDevice currentDevice].batteryMonitoringEnabled = TRUE`");
+        RCTLogWarn(@"Battery state is `unknown` which could mean battery monitoring is disabled. "
+                   "You may need to enable monitoring with `[UIDevice currentDevice].batteryMonitoringEnabled = TRUE`");
     }
 #endif
     return @{

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -419,12 +419,18 @@ RCT_EXPORT_METHOD(isPinOrFingerprintSet:(RCTResponseSenderBlock)callback)
 
 - (NSDictionary *)powerState
 {
-#if RCT_DEV && !TARGET_OS_TV && !TARGET_IPHONE_SIMULATOR
-    if ([UIDevice currentDevice].batteryState == UIDeviceBatteryStateUnknown) {
-        RCTLogWarn(@"Battery state is `unknown` which could mean battery monitoring is disabled. "
-                   "You may need to enable monitoring with `[UIDevice currentDevice].batteryMonitoringEnabled = TRUE`");
+#if RCT_DEV
+    if ([UIDevice currentDevice].isBatteryMonitoringEnabled != true) {
+        RCTLogWarn(@"Battery monitoring is not enabled. "
+                   "You Need to enable monitoring with `[UIDevice currentDevice].batteryMonitoringEnabled = TRUE`");
     }
 #endif
+#if RCT_DEV && (TARGET_OS_TV || TARGET_IPHONE_SIMULATOR)
+    if ([UIDevice currentDevice].batteryState == UIDeviceBatteryStateUnknown) {
+        RCTLogWarn(@"Battery state is `unknown` which is normal for simulators and tvOS.");
+    }
+#endif
+
     return @{
 #if TARGET_OS_TV
              @"batteryLevel": @1,

--- a/refresh-example.sh
+++ b/refresh-example.sh
@@ -14,6 +14,8 @@ else
   echo "Saving files to TEMP while refreshing scaffolding..."
   mkdir -p TEMP/android
   cp example/android/local.properties TEMP/android/ || true
+  mkdir -p TEMP/ios/example
+  cp example/ios/example/AppDelegate.m TEMP/ios/example/ || true
   cp example/App.js TEMP/
 fi
 

--- a/refresh-example.sh
+++ b/refresh-example.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e 
+set -e
 
 echo "You should run this from directory where you have cloned the react-native-device-info repo"
 echo "You should only do this when your git working set is completely clean (e.g., git reset --hard)"
@@ -14,8 +14,6 @@ else
   echo "Saving files to TEMP while refreshing scaffolding..."
   mkdir -p TEMP/android
   cp example/android/local.properties TEMP/android/ || true
-  mkdir -p TEMP/ios/example
-  cp example/ios/example/AppDelegate.m TEMP/ios/example/ || true
   cp example/App.js TEMP/
 fi
 
@@ -37,7 +35,7 @@ sed -i -e 's/INTERNET" \/>/INTERNET" \/><uses-permission android:name="android.p
 rm -f android/app/src/main/AndroidManifest.xml??
 
 # Patch the AppDelegate for iOS battery level
-sed -i -e 's/return YES;/\[UIDevice currentDevice\].batteryMonitoringEnabled = true; return YES;/' ios/example/AppDelegate.m
+sed -i -e $'s/return YES;/\[UIDevice currentDevice\].batteryMonitoringEnabled = true;\\\n  return YES;/' ios/example/AppDelegate.m
 rm -f ios/example/AppDelegate.m??
 
 # Copy the important files back in


### PR DESCRIPTION
## Description

Added `getPowerState()` that allows for fetching more detailed information about the power on the device. In addition to returning the battery level it includes information about the battery state (full, charging, etc.) and whether the system is operating in low power mode.

Additionally, this adds a few events that can be subscribed to in order to be notified when the battery level changes, state changes (for example, if the device is unplugged), or if the battery drops below 20%.

These additional capabilities are very helpful in our case as we want to trigger certain things within our app when an app intended for kiosk use is unplugged and starts depleting battery. It's also useful to know if the battery is low or the user has switched on low power mode so that we can defer certain actions until the battery is above a certain threshold.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`.
* [ ] I mentionned this change in `CHANGELOG.md`.
