### PR TITLE
Add android get installer package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### next
 
+* Add `getInstallerPackageName`
+
 ### 0.21.5
 
 * Rolled back the Pod change made in 0.21.1

--- a/README.md
+++ b/README.md
@@ -829,7 +829,7 @@ const isTablet = DeviceInfo.isTablet(); // true
 
 ### getInstallerPackageName()
 
-Retrieve the package name of the application that installed a package..
+Retrieve the package name of the application that installed a package.
 
 **Examples**
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ var DeviceInfo = require('react-native-device-info');
 | [isEmulator()](#isemulator)                       | `boolean`           |  ✅  |   ✅    |   ✅    | ?      |
 | [isPinOrFingerprintSet()](#ispinorfingerprintset) | (callback)`boolean` |  ✅  |   ✅    |   ✅    | 0.10.1 |
 | [isTablet()](#istablet)                           | `boolean`           |  ✅  |   ✅    |   ✅    | ?      |
+| [getInstallerPackageName()](#getInstallerPackage) | `boolean`           |  ❌  |   ✅    |   ❌    | ?      |
 
 ---
 
@@ -824,6 +825,16 @@ Tells if the device is a tablet.
 
 ```js
 const isTablet = DeviceInfo.isTablet(); // true
+```
+
+### getInstallerPackageName()
+
+Retrieve the package name of the application that installed a package..
+
+**Examples**
+
+```js
+const installerPackageName = DeviceInfo.getInstallerPackageName(); // com.android.vending
 ```
 
 ## Troubleshooting

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -220,6 +220,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
 
     PackageManager packageManager = this.reactContext.getPackageManager();
     String packageName = this.reactContext.getPackageName();
+    String installerPackageName = packageManager.getInstallerPackageName(packageName);
 
     constants.put("appVersion", "not available");
     constants.put("appName", "not available");
@@ -275,6 +276,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     constants.put("uniqueId", Secure.getString(this.reactContext.getContentResolver(), Secure.ANDROID_ID));
     constants.put("systemManufacturer", Build.MANUFACTURER);
     constants.put("bundleId", packageName);
+    constants.put("installerPackageName", installerPackageName);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
       try {
         constants.put("userAgent", WebSettings.getDefaultUserAgent(this.reactContext));

--- a/deviceinfo.d.ts
+++ b/deviceinfo.d.ts
@@ -40,3 +40,4 @@ export function getMaxMemory(): number;
 export function getTotalDiskCapacity(): number;
 export function getFreeDiskStorage(): number;
 export function getBatteryLevel(): Promise<number>;
+export function getInstallerPackageName(): string;

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -121,4 +121,7 @@ module.exports = {
   getBatteryLevel: function() {
     return RNDeviceInfo.getBatteryLevel();
   },
+  getInstallerPackageName: function() {
+    return RNDeviceInfo.installerPackageName;
+  },
 };

--- a/deviceinfo.js.flow
+++ b/deviceinfo.js.flow
@@ -40,4 +40,5 @@ declare module.exports: {
   getTotalDiskCapacity: () => number,
   getFreeDiskStorage: () => number,
   getBatteryLevel: () => Promise<number>,
+  getInstallerPackageName: () => string,
 };


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

<!-- OR, if you're implementing a new feature: -->

Added `getInstallerPackageName()` that retrieve the package name of the application that installed a package.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [X] I have tested this on a device/simulator for each compatible OS
* [X] I added the documentation in `README.md`.
* [X] I mentioned this change in `CHANGELOG.md`.
