### PR TITLE
Expose timezone and 24 hour properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Release Notes
 
 ### 0.25
+ * Expose getter methods for timezone and 24Hour time (https://github.com/rebeccahughes/react-native-device-info/pull/539)
  * Added `isAirPlaneMode()` (https://github.com/rebeccahughes/react-native-device-info/pull/524)
 
 ### 0.24.3
@@ -19,7 +20,7 @@
  * Add `hasNotch()` (https://github.com/rebeccahughes/react-native-device-info/pull/500)
 
 ### 0.22.6
- * Support new models (XR, XS, XS Max) and iPad 6th Gen (https://github.com/rebeccahughes/react-native-device-info/pull/499) 
+ * Support new models (XR, XS, XS Max) and iPad 6th Gen (https://github.com/rebeccahughes/react-native-device-info/pull/499)
 
 ### 0.22.5
  * Fix typescript declaration export (https://github.com/rebeccahughes/react-native-device-info/pull/478)
@@ -38,7 +39,7 @@
  * Fix deprecated code on Android in the following methods (https://github.com/rebeccahughes/react-native-device-info/pull/426)
  * getDeviceCountry
  * getDeviceLocale
- 
+
 ### 0.22.0
 
 * Add support for `getIpAddress` and `getMacAddress` on iOS (https://github.com/rebeccahughes/react-native-device-info/commit/41735bd0b2efe1f626afc066604f27073acb9d4c)

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -131,6 +131,20 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     return getReactApplicationContext().getResources().getConfiguration().fontScale;
   }
 
+  @ReactMethod
+  public void getTimezone(Promise p) {
+    p.resolve(this.timezone());
+  }
+
+  private String timezone() {
+      return TimeZone.getDefault().getID();
+  }
+
+  @ReactMethod
+  public void getIs24Hour(Promise p) {
+    p.resolve(this.is24Hour());
+  }
+
   private Boolean is24Hour() {
     return android.text.format.DateFormat.is24HourFormat(this.reactContext.getApplicationContext());
   }
@@ -306,7 +320,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
         constants.put("userAgent", System.getProperty("http.agent"));
       }
     }
-    constants.put("timezone", TimeZone.getDefault().getID());
+    constants.put("timezone", this.timezone());
     constants.put("isEmulator", this.isEmulator());
     constants.put("isTablet", this.isTablet());
     constants.put("fontScale", this.fontScale());

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -189,7 +189,7 @@ export default {
     return RNDeviceInfo.deviceCountry;
   },
   getTimezone: function() {
-    return RNDeviceInfo.timezone;
+    return RNDeviceInfo.getTimezone();
   },
   getFontScale: function() {
     return RNDeviceInfo.fontScale;
@@ -201,7 +201,7 @@ export default {
     return RNDeviceInfo.isTablet;
   },
   is24Hour: function() {
-    return RNDeviceInfo.is24Hour;
+    return RNDeviceInfo.getIs24Hour();
   },
   isPinOrFingerprintSet: function() {
     return RNDeviceInfo.isPinOrFingerprintSet;

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -197,10 +197,14 @@ RCT_EXPORT_MODULE(RNDeviceInfo)
   return country;
 }
 
-- (NSString*) timezone
+- (NSString*) getTimezone
 {
   NSTimeZone *currentTimeZone = [NSTimeZone localTimeZone];
   return currentTimeZone.name;
+}
+RCT_REMAP_METHOD(getTimezone, timezoneResolver:(RCTPromiseResolveBlock)resolve timezoneRejecter:(RCTPromiseRejectBlock)reject)
+{
+    resolve([self getTimezone]);
 }
 
 - (bool) isTablet
@@ -230,10 +234,14 @@ RCT_EXPORT_MODULE(RNDeviceInfo)
   return [NSNumber numberWithFloat: fontScale];
 }
 
-- (bool) is24Hour
+- (bool) getIs24Hour
 {
     NSString *format = [NSDateFormatter dateFormatFromTemplate:@"j" options:0 locale:[NSLocale currentLocale]];
     return ([format rangeOfString:@"a"].location == NSNotFound);
+}
+RCT_REMAP_METHOD(getIs24Hour, is24HourResolver:(RCTPromiseResolveBlock)resolve is24HourRejecter:(RCTPromiseRejectBlock)reject)
+{
+    resolve(@([self getIs24Hour]));
 }
 
 - (unsigned long long) totalMemory {
@@ -290,10 +298,10 @@ RCT_EXPORT_MODULE(RNDeviceInfo)
              @"systemManufacturer": @"Apple",
              @"carrier": self.carrier ?: [NSNull null],
              @"userAgent": self.userAgent ?: [NSNull null],
-             @"timezone": self.timezone ?: [NSNull null],
+             @"timezone": self.getTimezone ?: [NSNull null],
              @"isEmulator": @(self.isEmulator),
              @"isTablet": @(self.isTablet),
-             @"is24Hour": @(self.is24Hour),
+             @"is24Hour": @(self.getIs24Hour),
              @"fontScale": self.fontScale,
              @"totalMemory": @(self.totalMemory),
              @"totalDiskCapacity": @(self.totalDiskCapacity),


### PR DESCRIPTION
## Description

Exposes functions for getting updated values of `timezone` and `is24Hour`, instead of relying on static values.

Timezone and 24-hour time are both preferences that may change on the OS level as the user changes location or modifies their settings. Exposing these getter methods allows clients to pull the freshest value for these properties, as they may change while the app is still up.


## Checklist
<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* ~~[ ] I added the documentation in `README.md`.~~
* [x] I mentioned this change in `CHANGELOG.md`.
