### PR TITLE
Ignore missing permissions in lint, specify minor support library versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Release Notes
 
+### 0.29.1
+ * Fix lint errors (library dependences, ignore permissions) (https://github.com/react-native-community/react-native-device-info/pull/590)
+
 ### 0.29.0
  * Add `isAutoDateAndTime()` and `isAutoTimeZone()` (https://github.com/rebeccahughes/react-native-device-info/pull/583)
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,6 +4,7 @@ def DEFAULT_COMPILE_SDK_VERSION             = 28
 def DEFAULT_BUILD_TOOLS_VERSION             = "28.0.0"
 def DEFAULT_TARGET_SDK_VERSION              = 28
 def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION    = "+"
+def DEFAULT_SUPPORT_LIB_VERSION             = "28.0.0"
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? project.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
@@ -19,13 +20,17 @@ android {
         }
     }
     lintOptions {
-       warning 'InvalidPackage'
+       warning 'InvalidPackage', 'MissingPermission'
     }
 }
 
 dependencies {
     def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
+    def supportLibVersion = project.hasProperty('supportLibVersion') ? project.supportLibVersion : DEFAULT_SUPPORT_LIB_VERSION
 
     implementation 'com.facebook.react:react-native:+'
     implementation "com.google.android.gms:play-services-gcm:$googlePlayServicesVersion"
+    implementation "com.android.support:appcompat-v7:$supportLibVersion"
+    implementation "com.android.support:support-v4:$supportLibVersion"
+    implementation "com.android.support:support-media-compat:$supportLibVersion"
 }


### PR DESCRIPTION

Took the advice from a comment on the linked issue: https://github.com/react-native-community/react-native-device-info/issues/325#issuecomment-448498293

## Description

Should fix #325
