### PR TITLE
Getting podspec details from package information

### DIFF
--- a/RNDeviceInfo.podspec
+++ b/RNDeviceInfo.podspec
@@ -1,12 +1,16 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
 Pod::Spec.new do |s|
   s.name         = "RNDeviceInfo"
-  s.version      = "0.21.5"
-  s.summary      = "Device Information for react-native"
+  s.version      = package['version']
+  s.summary      = package['description']
 
-  s.homepage     = "https://github.com/rebeccahughes/react-native-device-info"
+  s.homepage     = package['repository']['url']
 
-  s.license      = "MIT"
-  s.authors      = { "Rebecca Hughes" => "rebecca@learnium.net" }
+  s.license      = package['license']
+  s.authors      = package['author']
   s.ios.deployment_target = '8.0'
   s.tvos.deployment_target = '10.0'
 


### PR DESCRIPTION
For example version is now hardcoded antique 0.21.5. So why not get needed details from package.json and those are always up-to-date.

## Description

Fixed podspec to be more dynamically.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |
| Windows |    ✅❌     |

## Checklist

* [X] I have tested this on a device/simulator for each compatible OS (tested that app with device-info dependency runs and works normally with iOS simulator after change)
* [ ] I mentioned this change in `CHANGELOG.md`.
