### PR TITLE
docs: Added troubleshooting info for CoreTelephony error log

### DIFF
--- a/README.md
+++ b/README.md
@@ -997,6 +997,18 @@ Seems to be a bug caused by `react-native link`. You can manually delete `libRND
 </details>
 
 <details>
+  <summary>[ios] - [NetworkInfo] Descriptors query returned error: Error Domain=NSCocoaErrorDomain Code=4099
+ “The connection to service named com.apple.commcenter.coretelephony.xpc was invalidated.”</summary>
+
+This is a system level log that may be turned off by executing: 
+```xcrun simctl spawn booted log config --mode "level:off"  --subsystem com.apple.CoreTelephony```. 
+To undo the command, you can execute: 
+```xcrun simctl spawn booted log config --mode "level:info"  --subsystem com.apple.CoreTelephony```
+
+</details>
+
+
+<details>
   <summary>[tests] - Cannot run my test suite when using this library</summary>
 
 `react-native-device-info` contains native code, and needs to be mocked.


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixed issue #562

<!-- OR, if you're implementing a new feature: -->

Added troubleshooting info for CoreTelephony error log - *[NetworkInfo] Descriptors query returned error: Error Domain=NSCocoaErrorDomain Code=4099  “The connection to service named com.apple.commcenter.coretelephony.xpc was invalidated.”*

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`.
* [ ] I mentioned this change in `CHANGELOG.md`.
