### PR TITLE
fix: Make GCM inclusion optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Release Notes
 
+### 2.0.0
+
+ * Remove the `googlePlayServicesVersion` Gradle build config and allow users to include their GCM only if they need it
 
 ### 1.1.0
  * Add `supportedABIs()` (https://github.com/react-native-community/react-native-device-info/pull/598)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ yarn add react-native-device-info
 ```
 
 > ⚠️ If you are on React Native > 0.47, you must use version 0.11.0 of this library or higher
-> ⚠️ If you want to use `DeviceInfo.getInstanceID` on Android make sure to [include Google play services base in your app](#optional-getinstanceid).
+
+> ⚠️ If you want to use `DeviceInfo.getInstanceID` on Android make sure to [include Google play services base in your app](#getinstanceid).
 
 ## Linking
 
@@ -107,7 +108,7 @@ dependencies {
 }
 ```
 
-* <a name="optional-getinstanceid"></a> **_optional_** in `android/app/build.gradle` if you want to use `DeviceInfo.getInstanceID`:
+* **_optional_** in `android/app/build.gradle` if you want to use `DeviceInfo.getInstanceID`:
 
 ```diff
 dependencies {
@@ -556,7 +557,16 @@ const instanceId = DeviceInfo.getInstanceID();
 
 **Notes**
 
-> ⚠️ To use this on Android you must have [Google play services base installed in your app](#optional-getinstanceid)
+To get correct value on android you must add the following in your `android/app/build.gradle`:
+
+```diff
+dependencies {
+    ...
+    implementation "com.facebook.react:react-native:+"  // From node_modules
++   implementation "com.google.android.gms:play-services-gcm:+"
+}
+```
+
 > See https://developers.google.com/instance-id/
 
 ---

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ yarn add react-native-device-info
 ```
 
 > ⚠️ If you are on React Native > 0.47, you must use version 0.11.0 of this library or higher
+> ⚠️ If you want to use `DeviceInfo.getInstanceID` on Android make sure to [include Google play services base in your app](#optional-getinstanceid).
 
 ## Linking
 
@@ -89,7 +90,6 @@ Run your project (Cmd+R)
 ...
   ext {
     // dependency versions
-    googlePlayServicesVersion = "<Your play services version>" // default: "+"
     compileSdkVersion = "<Your compile SDK version>" // default: 23
     buildToolsVersion = "<Your build tools version>" // default: "25.0.2"
     targetSdkVersion = "<Your target SDK version>" // default: 22
@@ -104,6 +104,16 @@ dependencies {
     ...
     implementation "com.facebook.react:react-native:+"  // From node_modules
 +   implementation project(':react-native-device-info')
+}
+```
+
+* <a name="optional-getinstanceid"></a> **_optional_** in `android/app/build.gradle` if you want to use `DeviceInfo.getInstanceID`:
+
+```diff
+dependencies {
+    ...
+    implementation "com.facebook.react:react-native:+"  // From node_modules
++   implementation "com.google.android.gms:play-services-gcm:+"
 }
 ```
 
@@ -546,6 +556,7 @@ const instanceId = DeviceInfo.getInstanceID();
 
 **Notes**
 
+> ⚠️ To use this on Android you must have [Google play services base installed in your app](#optional-getinstanceid)
 > See https://developers.google.com/instance-id/
 
 ---
@@ -972,11 +983,6 @@ When installing or using `react-native-device-info`, you may encounter the follo
   <summary>[android] - Unable to merge dex / Multiple dex files / Problems with `com.google.android.gms`</summary>
 
 `react-native-device-info` uses `com.google.android.gms:play-services-gcm` to provide [getInstance()][#getinstance].
-This can lead to conflicts when building the Android application.
-
-If you're using a different version of `com.google.android.gms:play-services-gcm` in your app, you can define the
-`googlePlayServicesVersion` gradle variable in your `build.gradle` file to tell `react-native-device-info` what version
-it should require.
 
 If you're using a different library that conflicts with `com.google.android.gms:play-services-gcm`, you can simply
 ignore this dependency in your gradle file:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'com.android.library'
 def DEFAULT_COMPILE_SDK_VERSION             = 28
 def DEFAULT_BUILD_TOOLS_VERSION             = "28.0.0"
 def DEFAULT_TARGET_SDK_VERSION              = 28
-def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION    = "+"
 def DEFAULT_SUPPORT_LIB_VERSION             = "28.0.0"
 
 android {
@@ -25,11 +24,9 @@ android {
 }
 
 dependencies {
-    def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
     def supportLibVersion = project.hasProperty('supportLibVersion') ? project.supportLibVersion : DEFAULT_SUPPORT_LIB_VERSION
 
     implementation 'com.facebook.react:react-native:+'
-    implementation "com.google.android.gms:play-services-gcm:$googlePlayServicesVersion"
     implementation "com.android.support:appcompat-v7:$supportLibVersion"
     implementation "com.android.support:support-v4:$supportLibVersion"
     implementation "com.android.support:support-media-compat:$supportLibVersion"

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -37,6 +37,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.lang.Runtime;
 import java.net.NetworkInterface;
 import java.math.BigInteger;

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -345,11 +345,23 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
 
 
     try {
-      if (Class.forName("com.google.android.gms.iid.InstanceID") != null) {
-        constants.put("instanceId", com.google.android.gms.iid.InstanceID.getInstance(this.reactContext).getId());
-      }
-    } catch (ClassNotFoundException e) {
-      constants.put("instanceId", "N/A: Add com.google.android.gms:play-services-gcm to your project.");
+        if (Class.forName("com.google.android.gms.iid.InstanceID") != null) {
+            Class cls = Class.forName("com.google.android.gms.iid.InstanceID");
+
+            Class[] paramString = new Class[1];
+            paramString[0] = Context.class;
+            Method getInstanceMethod = cls.getDeclaredMethod("getInstance", paramString);
+            Object appInstance = getInstanceMethod.invoke(null, this.reactContext);
+
+            Method getIdMethod = cls.getDeclaredMethod("getId");
+            String instanceId = (String) getIdMethod.invoke(appInstance);
+
+            constants.put("instanceId", instanceId);
+        } else {
+            constants.put("instanceId", "N/A: Add com.google.android.gms:play-services-gcm to your project.");
+        }
+    } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+        constants.put("instanceId", "N/A: Add com.google.android.gms:play-services-gcm to your project.");
     }
     constants.put("serialNumber", Build.SERIAL);
     constants.put("deviceName", deviceName);

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext {        googlePlayServicesVersion = "16.1.0"
+    ext {
         buildToolsVersion = "28.0.2"
         minSdkVersion = 16
         compileSdkVersion = 28


### PR DESCRIPTION
## Description

Fixed issue #381

[GCM](https://developers.google.com/cloud-messaging/) has been deprecated by google. This PR gives control over to the consumer whether they want to include GCM in their app or not. This is achieved by using Java reflections APIs to dynamically instantiate GCM InstanceID object only when it is available.

fixes issue #381

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

* [X] I have tested this on a device/simulator for each compatible OS
* [X] I added the documentation in `README.md`
* [X] I mentioned this change in `CHANGELOG.md`
* [X] I updated the typings files (`deviceinfo.d.ts`, `deviceinfo.js.flow`)
* [X] I updated the web polyfill (`web/index.js`)
