### PR TITLE
feat: Add preferred Languages function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Release Notes
 
 ### 1.3.0
- * feat: Add support for preferred languages function (https://github.com/react-native-community/react-native-device-info/pull/610/files)
+ * feat: Add support for preferred languages function (https://github.com/react-native-community/react-native-device-info/pull/610)
 
 ### 1.2.0
  * feat: Support 'dom' Platform.OS for react-native-dom (https://github.com/react-native-community/react-native-device-info/pull/406)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Release Notes
 
+### 1.3.0
+ * feat: Add support for preferred languages function
+
 ### 1.2.0
  * feat: Support 'dom' Platform.OS for react-native-dom (https://github.com/react-native-community/react-native-device-info/pull/406)
  * feat: Add support for jest snapshot testing (https://github.com/react-native-community/react-native-device-info/pull/375)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Release Notes
 
 ### 1.3.0
- * feat: Add support for preferred languages function
+ * feat: Add support for preferred languages function (https://github.com/react-native-community/react-native-device-info/pull/610/files)
 
 ### 1.2.0
  * feat: Support 'dom' Platform.OS for react-native-dom (https://github.com/react-native-community/react-native-device-info/pull/406)

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ import DeviceInfo from 'react-native-device-info';
 | [getDeviceCountry()](#getdevicecountry)           | `string`            |  ✅  |   ✅    |   ✅    | 0.9.0  |
 | [getDeviceId()](#getdeviceid)                     | `string`            |  ✅  |   ✅    |   ✅    | 0.5.0  |
 | [getDeviceLocale()](#getdevicelocale)             | `string`            |  ✅  |   ✅    |   ✅    | 0.7.0  |
+| [getPreferredLocales()](#getpreferredlocale)      | `Array<string>`     |  ✅  |   ✅    |   ❌    | ?      |
 | [getDeviceName()](#getdevicename)                 | `string`            |  ✅  |   ✅    |   ✅    | ?      |
 | [getFirstInstallTime()](#getfirstinstalltime)     | `number`            |  ❌  |   ✅    |   ✅    | 0.12.0 |
 | [getFontScale()](#getfontscale)                   | `number`            |  ✅  |   ✅    |   ❌    | 0.15.0 |
@@ -415,6 +416,22 @@ const deviceLocale = DeviceInfo.getDeviceLocale();
 
 // iOS: "en"
 // Android: "en-US"
+// Windows: ?
+```
+
+---
+
+### getPreferredLocales()
+
+Gets the preferred locales defined by the user.
+
+**Examples**
+
+```js
+const preferredLocales = DeviceInfo.getPreferredLocales();
+
+// iOS: "[es-ES, en-US]"
+// Android: "[es-ES, en-US]"
 // Windows: ?
 ```
 

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -34,6 +34,7 @@ import com.facebook.react.bridge.Promise;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
@@ -90,6 +91,20 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
       }
       return builder.toString();
     }
+  }
+
+  private ArrayList<String> getPreferredLocales() {
+    Configuration configuration = getReactApplicationContext().getResources().getConfiguration();
+    ArrayList<String> preferred = new ArrayList<>();
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      for (int i = 0; i < configuration.getLocales().size(); i++) {
+        preferred.add(configuration.getLocales().get(i).getLanguage());
+      }
+    } else {
+      preferred.add(configuration.locale.getLanguage());
+    }
+
+    return preferred;
   }
 
   private String getCurrentCountry() {
@@ -360,6 +375,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     constants.put("deviceId", Build.BOARD);
     constants.put("apiLevel", Build.VERSION.SDK_INT);
     constants.put("deviceLocale", this.getCurrentLanguage());
+    constants.put("preferredLocales", this.getPreferredLocales());
     constants.put("deviceCountry", this.getCurrentCountry());
     constants.put("uniqueId", Settings.Secure.getString(this.reactContext.getContentResolver(), Settings.Secure.ANDROID_ID));
     constants.put("systemManufacturer", Build.MANUFACTURER);

--- a/default/index.js
+++ b/default/index.js
@@ -22,6 +22,7 @@ module.exports = {
   deviceName: '',
   userAgent: '',
   deviceLocale: '',
+  preferredLocales: [],
   deviceCountry: '',
   timezone: '',
   fontScale: 0,

--- a/deviceinfo.d.ts
+++ b/deviceinfo.d.ts
@@ -19,6 +19,7 @@ declare const _default: {
   getDeviceName: () => string;
   getUserAgent: () => string;
   getDeviceLocale: () => string;
+  getPreferredLocales: () => Array<string>;
   getDeviceCountry: () => string;
   getTimezone: () => string;
   getInstanceID: () => string;

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -257,6 +257,9 @@ export default {
   getDeviceLocale: function() {
     return RNDeviceInfo.deviceLocale;
   },
+  getPreferredLocales: function() {
+    return RNDeviceInfo.preferredLocales;
+  },
   getDeviceCountry: function() {
     return RNDeviceInfo.deviceCountry;
   },

--- a/deviceinfo.js.flow
+++ b/deviceinfo.js.flow
@@ -18,6 +18,7 @@ declare module.exports: {
   getDeviceName: () => string,
   getUserAgent: () => string,
   getDeviceLocale: () => string,
+  getPreferredLocales: () => Array<string>,
   getDeviceCountry: () => string,
   getTimezone: () => string,
   getInstanceID: () => string,

--- a/example/App.js
+++ b/example/App.js
@@ -48,6 +48,7 @@ export default class App extends Component<Props> {
       deviceJSON.deviceName = DeviceInfo.getDeviceName(); // needs android.permission.BLUETOOTH ?
       deviceJSON.userAgent = DeviceInfo.getUserAgent();
       deviceJSON.deviceLocale = DeviceInfo.getDeviceLocale();
+      deviceJSON.preferredLocales = DeviceInfo.getPreferredLocales();
       deviceJSON.deviceCountry = DeviceInfo.getDeviceCountry();
       deviceJSON.timezone = DeviceInfo.getTimezone();
       deviceJSON.instanceID = ios ? '' : DeviceInfo.getInstanceID();

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -197,11 +197,16 @@ RCT_EXPORT_MODULE(RNDeviceInfo)
 
 - (NSString*) deviceLocale
 {
-    NSString *language = [[NSLocale preferredLanguages] objectAtIndex:0];
+    NSString *language = [[NSLocale preferredLanguages] firstObject];
     return language;
 }
 
-- (NSString*) deviceCountry
+- (NSString*) preferredLocales
+{
+    return [NSLocale preferredLanguages];
+}
+
+- (NSString*) deviceCountry 
 {
   NSString *country = [[NSLocale currentLocale] objectForKey:NSLocaleCountryCode];
   return country;
@@ -307,6 +312,7 @@ RCT_EXPORT_MODULE(RNDeviceInfo)
              @"deviceId": self.deviceId ?: [NSNull null],
              @"deviceName": currentDevice.name,
              @"deviceLocale": self.deviceLocale ?: [NSNull null],
+             @"preferredLocales": self.preferredLocales ?: [NSNull null],
              @"deviceCountry": self.deviceCountry ?: [NSNull null],
              @"uniqueId": uniqueId,
              @"appName": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] ?: [NSNull null],


### PR DESCRIPTION
## Description

This PR exposes the functions to return the preferred languages set up by the user in the Android and iOS devices.
As a user, you can customize what are your preferred languages. Right now, `react-native-device-info` just return the first value from this list, but there are scenarios where we need to have the whole preferred languages in order to see if they fit with the supported language that the `react-native-app` support.

Added `getPreferredLocales()` that returns the list of preferred languages set up in the Android or iOS device.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [✅] I have tested this on a device/simulator for each compatible OS
* [✅] I added the documentation in `README.md`
* [ ✅] I mentioned this change in `CHANGELOG.md`
* [✅] I updated the typings files (`deviceinfo.d.ts`, `deviceinfo.js.flow`)
* [✅ ] I updated the web polyfill (`web/index.js`)
