### PR TITLE
Add the 3th generation iPad pro to the device name list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Release Notes
 
+### Next:
+ * Added the 3rd generation iPad pro to the deviceNamesByCode list (https://github.com/react-native-community/react-native-device-info/pull/618)
+	
+**iOS warning:**  The list with device names (returned by `getModel()`) is maintained by the community and could lag new devices. It is recommended to use `getDeviceId()	` since it's more reliable and always up-to-date with new iOS devices. We do accept pull requests that add new iOS devices to the list with device names.
+
 ### 1.4.1
  * fix: repair flow types from #436 - 'Object' vs 'object'
 

--- a/README.md
+++ b/README.md
@@ -636,6 +636,8 @@ const maxMemory = DeviceInfo.getMaxMemory(); // 402653183
 
 Gets the device model.
 
+**iOS warning:**  The list with device names is maintained by the community and could lag new devices. It is recommended to use `getDeviceId()	` since it's more reliable and always up-to-date with new iOS devices. We do accept pull requests that add new iOS devices to the list with device names.
+
 **Examples**
 
 ```js

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -176,6 +176,14 @@ RCT_EXPORT_MODULE(RNDeviceInfo);
                               @"iPad7,4"   :@"iPad Pro 10.5-inch",// iPad Pro 10.5-inch - Cellular
                               @"iPad7,5"   :@"iPad (6th generation)",// iPad (6th generation) - Wifi
                               @"iPad7,6"   :@"iPad (6th generation)",// iPad (6th generation) - Cellular
+                              @"iPad8,1"   :@"iPad Pro 11-inch (3rd generation)", // iPad Pro 11 inch (3rd generation) - Wifi
+                              @"iPad8,2"   :@"iPad Pro 11-inch (3rd generation)", // iPad Pro 11 inch (3rd generation) - 1TB - Wifi
+                              @"iPad8,3"   :@"iPad Pro 11-inch (3rd generation)", // iPad Pro 11 inch (3rd generation) - Wifi + cellular
+                              @"iPad8,4"   :@"iPad Pro 11-inch (3rd generation)", // iPad Pro 11 inch (3rd generation) - 1TB - Wifi + cellular
+                              @"iPad8,5"   :@"iPad Pro 12.9-inch (3rd generation)", // iPad Pro 12.9 inch (3rd generation) - Wifi
+                              @"iPad8,6"   :@"iPad Pro 12.9-inch (3rd generation)", // iPad Pro 12.9 inch (3rd generation) - 1TB - Wifi
+                              @"iPad8,7"   :@"iPad Pro 12.9-inch (3rd generation)", // iPad Pro 12.9 inch (3rd generation) - Wifi + cellular
+                              @"iPad8,8"   :@"iPad Pro 12.9-inch (3rd generation)", // iPad Pro 12.9 inch (3rd generation) - 1TB - Wifi + cellular
                               @"AppleTV2,1":@"Apple TV",        // Apple TV (2nd Generation)
                               @"AppleTV3,1":@"Apple TV",        // Apple TV (3rd Generation)
                               @"AppleTV3,2":@"Apple TV",        // Apple TV (3rd Generation - Rev A)


### PR DESCRIPTION
## Description
I've added the 3rd generation Ipad pro to the list with available devices. This fixes a problem where it just returns "iPad" for these devices.

I've specifically added 3th generation to the name of the device. This way you can actually tell the difference between the multiple versions of the iPad Pro. This is a must have because it's the only way to tell the difference between the iPad pro with physical home button (generation 1 and 2) and the iPad pro without physical home button (generation 3). I kept the name of generation 2 the same for now but I can rename it for consistency.