### PR TITLE
chore: add ability to test flow and typescript definitions from command line

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,11 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[lints]
+
+[options]
+
+[strict]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-device-info",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -429,6 +429,12 @@
       "requires": {
         "locate-path": "^2.0.0"
       }
+    },
+    "flow-bin": {
+      "version": "0.96.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.96.0.tgz",
+      "integrity": "sha512-OSxERs0EdhVxEVCst/HmlT/RcnXsQQIRqcfK9J9wC8/93JQj+xQz4RtlsmYe1PSRYaozuDLyPS5pIA81Zwzaww==",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1939,6 +1939,12 @@
       "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
       "dev": true
     },
+    "typescript": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.1.tgz",
+      "integrity": "sha512-3NSMb2VzDQm8oBTLH6Nj55VVtUEpe/rgkIzMir0qVoLyjDZlnMBva0U6vDiV3IH+sl/Yu6oP5QwsAQtHPmDd2Q==",
+      "dev": true
+    },
     "unique-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/react-native-community/react-native-device-info"
   },
   "scripts": {
+    "ts-check": "npx tsc deviceinfo.d.ts --noEmit",
     "flow-check": "npx flow check-contents < deviceinfo.js.flow",
     "shipit": "np"
   },
@@ -44,6 +45,7 @@
   "devDependencies": {
     "flow-bin": "^0.96.0",
     "np": "^2.16.0",
-    "prettier": "^1.10.2"
+    "prettier": "^1.10.2",
+    "typescript": "^3.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/react-native-community/react-native-device-info"
   },
   "scripts": {
+    "flow-check": "npx flow check-contents < deviceinfo.js.flow",
     "shipit": "np"
   },
   "keywords": [
@@ -41,6 +42,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "flow-bin": "^0.96.0",
     "np": "^2.16.0",
     "prettier": "^1.10.2"
   }


### PR DESCRIPTION
This is related to #614 - it doesn't implement CI but in looking at #613 I realized we could at least run a flow check from the command line. We also provide typescript definitions, so I added the ability to check that as well

It is not integrated with anything automated at the moment, that would be the real CI solution traced as #614 