### PR TITLE
Fixed #621 Feat: Throw an error if the native module is null with steps to help fix the issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Release Notes
 
+### Next
+ * Feat: Throw error if native module is null wwsteps to help fix (https://github.com/react-native-community/react-native-device-info/pull/630)
+
 ### 1.4.2:
  * fix: Use `RCTSharedApplication` so compile works for ios app extensions (https://github.com/react-native-community/react-native-device-info/pull/408)
  * chore: Add 3rd generation iPad pro to device/model list (https://github.com/react-native-community/react-native-device-info/pull/618)

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -5,8 +5,25 @@ import { Platform, NativeModules, Dimensions } from 'react-native';
 
 var RNDeviceInfo = NativeModules.RNDeviceInfo;
 
+if (Platform.OS === 'web' || Platform.OS === 'dom') {
+  RNDeviceInfo = require('./web');
+}
 if (!RNDeviceInfo) {
-  RNDeviceInfo = (Platform.OS === 'web' || Platform.OS === 'dom') ? require('./web') : require('./default');
+  // Produce an error if we don't have the native module
+  if (
+    Platform.OS === 'android' ||
+    Platform.OS === 'ios' ||
+    Platform.OS === 'web' ||
+    Platform.OS === 'dom'
+  ) {
+    throw new Error(`@react-native-community/react-native-device-info: NativeModule.RNDeviceInfo is null. To fix this issue try these steps:
+  • Run \`react-native link react-native-device-info\` in the project root.
+  • Rebuild and re-run the app.
+  • If you are using CocoaPods on iOS, run \`pod install\` in the \`ios\` directory and then rebuild and re-run the app. You may also need to re-open Xcode to get the new pods.
+  If none of these fix the issue, please open an issue on the Github repository: https://github.com/react-native-community/react-native-device-info`);
+  }
+
+  RNDeviceInfo = require('./default');
 }
 
 const devicesWithNotch = [


### PR DESCRIPTION
## Description

Fixed issue #621 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅*     |

* Due to lack of devices/OS I was not able to test the Windows part.

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`deviceinfo.d.ts`, `deviceinfo.js.flow`)
* [ ] I updated the web polyfill (`web/index.js`)

Didn't do the above steps as I feel those aren't needed for this PR.
