### PR TITLE
Xiaomi Brand name Capital corrected

### DIFF
--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -184,39 +184,39 @@ const devicesWithNotch = [
     model: 'X21 UD',
   },
   {
-    brand: 'xiaomi',
+    brand: 'Xiaomi',
     model: 'MI 8',
   },
   {
-    brand: 'xiaomi',
+    brand: 'Xiaomi',
     model: 'MI 8 Explorer Edition',
   },
   {
-    brand: 'xiaomi',
+    brand: 'Xiaomi',
     model: 'MI 8 SE',
   },
   {
-    brand: 'xiaomi',
+    brand: 'Xiaomi',
     model: 'MI 8 UD',
   },
   {
-    brand: 'xiaomi',
+    brand: 'Xiaomi',
     model: 'MI8Lite',
   },
   {
-    brand: 'xiaomi',
+    brand: 'Xiaomi',
     model: 'POCO F1',
   },
   {
-    brand: 'xiaomi',
+    brand: 'Xiaomi',
     model: 'POCOPHONE F1',
   },
   {
-    brand: 'xiaomi',
+    brand: 'Xiaomi',
     model: 'Redmi 6 Pro',
   },
   {
-    brand: 'xiaomi',
+    brand: 'Xiaomi',
     model: 'Mi A2 Lite',
   },
 ];


### PR DESCRIPTION
## Description

Hello, I noticed that "hasNotch()" does not work on my Xiaomi Mi 8, I had a look why and noticed that the brand name return Xiaomi but the brand name of all Xiaomis in "devicesWithNotch" is xiaomi, so I corrected this and have tested on my Xiaomi Mi 8, hasNotch now works.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [ ] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`deviceinfo.d.ts`, `deviceinfo.js.flow`)
* [ ] I updated the web polyfill (`web/index.js`)