### PR TITLE
Add build number of the operating system.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Next
 
+### 1.4.4
+ * feat: Add `getBuildId` method to gets build number of the operating system. (https://github.com/react-native-community/react-native-device-info/pull/640)
+
 ### 1.4.3
  * chore: Add Xiaomi Mi A2 Lite to devices with notch (https://github.com/react-native-community/react-native-device-info/pull/634)
  * feat: Throw error if native module is null w/steps to help fix (https://github.com/react-native-community/react-native-device-info/pull/630)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Next
 
-### 1.4.4
+### 1.5.0
  * feat: Add `getBuildId` method to gets build number of the operating system. (https://github.com/react-native-community/react-native-device-info/pull/640)
 
 ### 1.4.3

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ import DeviceInfo from 'react-native-device-info';
 | [getSerialNumber()](#getserialnumber)             | `string`            |  ❌  |   ✅    |   ❌    | 0.12.0 |
 | [getSystemName()](#getsystemname)                 | `string`            |  ✅  |   ✅    |   ✅    | ?      |
 | [getSystemVersion()](#getsystemversion)           | `string`            |  ✅  |   ✅    |   ✅    | ?      |
+| [getBuildId()](#getbuildid)                       | `string`            |  ✅  |   ✅    |   ❌    | ?      |
 | [getTimezone()](#gettimezone)                     | `string`            |  ✅  |   ✅    |   ✅    | ?      |
 | [getTotalDiskCapacity()](#gettotaldiskcapacity)   | `number`            |  ✅  |   ✅    |   ❌    | 0.15.0 |
 | [getTotalMemory()](#gettotalmemory)               | `number`            |  ✅  |   ✅    |   ❌    | 0.14.0 |

--- a/README.md
+++ b/README.md
@@ -757,6 +757,22 @@ const systemVersion = DeviceInfo.getSystemVersion();
 
 ---
 
+### getBuildId()
+
+Gets build number of the operating system.
+
+**Examples**
+
+```js
+const osBuildId = DeviceInfo.getBuildId();
+
+// iOS: "12A269"
+// Android: "13D15"
+// Windows: not support
+```
+
+---
+
 ### getTimezone()
 
 Gets the device default timezone.

--- a/README.md
+++ b/README.md
@@ -768,6 +768,7 @@ Gets build number of the operating system.
 const osBuildId = DeviceInfo.getBuildId();
 
 // iOS: "12A269"
+// tvOS: not available
 // Android: "13D15"
 // Windows: not available
 ```
@@ -844,6 +845,7 @@ Gets the device User Agent.
 const userAgent = DeviceInfo.getUserAgent();
 
 // iOS: "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143"
+// tvOS: not available
 // Android: ?
 // Windows: ?
 ```

--- a/README.md
+++ b/README.md
@@ -769,7 +769,7 @@ const osBuildId = DeviceInfo.getBuildId();
 
 // iOS: "12A269"
 // Android: "13D15"
-// Windows: not support
+// Windows: not available
 ```
 
 ---

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -372,6 +372,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     constants.put("systemVersion", Build.VERSION.RELEASE);
     constants.put("model", Build.MODEL);
     constants.put("brand", Build.BRAND);
+    constants.put("buildId", Build.ID);
     constants.put("deviceId", Build.BOARD);
     constants.put("apiLevel", Build.VERSION.SDK_INT);
     constants.put("deviceLocale", this.getCurrentLanguage());

--- a/default/index.js
+++ b/default/index.js
@@ -14,6 +14,7 @@ module.exports = {
   brand: '',
   systemName: '',
   systemVersion: '',
+  buildId: '',
   apiLevel: 0,
   bundleId: '',
   appName: '',

--- a/deviceinfo.d.ts
+++ b/deviceinfo.d.ts
@@ -11,6 +11,7 @@ declare const _default: {
   getDeviceId: () => string;
   getSystemName: () => string;
   getSystemVersion: () => string;
+  getBuildId: () => string;
   getBundleId: () => string;
   getApplicationName: () => string;
   getBuildNumber: () => string;

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -255,6 +255,9 @@ export default {
   getSystemVersion: function() {
     return RNDeviceInfo.systemVersion;
   },
+  getBuildId: function() {
+    return RNDeviceInfo.buildId;
+  },
   getAPILevel: function() {
     return RNDeviceInfo.apiLevel;
   },

--- a/deviceinfo.js.flow
+++ b/deviceinfo.js.flow
@@ -10,6 +10,7 @@ declare module.exports: {
   getDeviceId: () => string,
   getSystemName: () => string,
   getSystemVersion: () => string,
+  getBuildId: () => string,
   getBundleId: () => string,
   getApplicationName: () => string,
   getBuildNumber: () => string,

--- a/example/App.js
+++ b/example/App.js
@@ -41,6 +41,7 @@ export default class App extends Component<Props> {
       deviceJSON.deviceId = DeviceInfo.getDeviceId();
       deviceJSON.systemName = DeviceInfo.getSystemName();
       deviceJSON.systemVersion = DeviceInfo.getSystemVersion();
+      deviceJSON.buildId = DeviceInfo.getBuildId();
       deviceJSON.bundleId = DeviceInfo.getBundleId();
       deviceJSON.buildNumber = DeviceInfo.getBuildNumber();
       deviceJSON.version = DeviceInfo.getVersion();

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -349,13 +349,17 @@ RCT_EXPORT_MODULE(RNDeviceInfo);
 
 
 - (NSString *)getBuildId {
-    size_t bufferSize = 64;
-    NSMutableData *buffer = [[NSMutableData alloc] initWithLength:bufferSize];
-    int status = sysctlbyname("kern.osversion", buffer.mutableBytes, &bufferSize, NULL, 0);
-    if (status != 0) {
-        return nil;
-    }
-    return [[NSString alloc] initWithCString:buffer.mutableBytes encoding:NSUTF8StringEncoding];
+    #if TARGET_OS_TV
+        return @"not available";
+    #else
+        size_t bufferSize = 64;
+        NSMutableData *buffer = [[NSMutableData alloc] initWithLength:bufferSize];
+        int status = sysctlbyname("kern.osversion", buffer.mutableBytes, &bufferSize, NULL, 0);
+        if (status != 0) {
+            return @"not available";
+        }
+        return [[NSString alloc] initWithCString:buffer.mutableBytes encoding:NSUTF8StringEncoding];
+    #endif
 }
 
 - (NSDictionary *)constantsToExport

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -28,6 +28,7 @@ typedef NS_ENUM(NSInteger, DeviceType) {
 
 #if !(TARGET_OS_TV)
 @import CoreTelephony;
+@import Darwin.sys.sysctl;
 #endif
 
 @implementation RNDeviceInfo
@@ -346,6 +347,17 @@ RCT_EXPORT_MODULE(RNDeviceInfo);
     return typeOfCpu;
 }
 
+
+- (NSString *)getBuildId {
+    size_t bufferSize = 64;
+    NSMutableData *buffer = [[NSMutableData alloc] initWithLength:bufferSize];
+    int status = sysctlbyname("kern.osversion", buffer.mutableBytes, &bufferSize, NULL, 0);
+    if (status != 0) {
+        return nil;
+    }
+    return [[NSString alloc] initWithCString:buffer.mutableBytes encoding:NSUTF8StringEncoding];
+}
+
 - (NSDictionary *)constantsToExport
 {
     UIDevice *currentDevice = [UIDevice currentDevice];
@@ -366,6 +378,7 @@ RCT_EXPORT_MODULE(RNDeviceInfo);
              @"bundleId": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIdentifier"] ?: [NSNull null],
              @"appVersion": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"] ?: [NSNull null],
              @"buildNumber": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"] ?: [NSNull null],
+             @"buildId": [self getBuildId],
              @"systemManufacturer": @"Apple",
              @"carrier": self.carrier ?: [NSNull null],
              @"userAgent": self.userAgent ?: [NSNull null],

--- a/windows/RNDeviceInfo/RNDeviceInfoModule.cs
+++ b/windows/RNDeviceInfo/RNDeviceInfoModule.cs
@@ -172,6 +172,7 @@ namespace RNDeviceInfo
                 constants["apiLevel"] = "not available";
                 constants["model"] = model;
                 constants["brand"] = model;
+                constants["buildId"] = "not available";
                 constants["deviceId"] = hardwareVersion;
                 constants["deviceLocale"] = culture.Name;
                 constants["deviceCountry"] = culture.EnglishName;


### PR DESCRIPTION
## Description

Added `getBuildId()` that allows to gets build number of the operating system.
> **Note**: This method helps users' want's to [integrate with **Google Ads**](https://developers.google.com/app-conversion-tracking/api/request-response-specs) and this parameter is required to track their campaigns.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS          |     ✅     |
| Android   |     ✅     |
| Windows |     ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [X] I added the documentation in `README.md`
* [X] I mentioned this change in `CHANGELOG.md`
* [X] I updated the typings files (`deviceinfo.d.ts`, `deviceinfo.js.flow`)
* [ ] I updated the web polyfill (`web/index.js`)
