### PR TITLE
Add permissions for Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Next
 
+ * fix: Update Android permissions for contacts, WiFi status
+
 ### 1.5.0
  * feat: Add `getBuildId` method to gets build number of the operating system. (https://github.com/react-native-community/react-native-device-info/pull/640)
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.learnium.RNDeviceInfo">
           
+    
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.READ_PHONE_NUMBERS" />
+          
     <application>
         <receiver
             android:name="com.learnium.RNDeviceInfo.RNDeviceReceiver"


### PR DESCRIPTION
## Description

Fixed an issue where gradle build would barf on missing permissions for WiFi and phone numbers.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [X] I have tested this on a device/simulator for each compatible OS
* [n/a] I added the documentation in `README.md`
* [X] I mentioned this change in `CHANGELOG.md`
* [n/a] I updated the typings files (`deviceinfo.d.ts`, `deviceinfo.js.flow`)
* [n/a] I updated the web polyfill (`web/index.js`)
