### PR TITLE
Fix android build number type inconsistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Release Notes
 
 ### Next
+ * fix: Android `getBuildNumber` now returns a string (https://github.com/react-native-community/react-native-device-info/pull/648)
 
 ### 1.5.1
  * chore: Update deviceinfo.js entry for xioami mi 8 lite (https://github.com/react-native-community/react-native-device-info/pull/644)

--- a/README.md
+++ b/README.md
@@ -345,13 +345,9 @@ Gets the application build number.
 const buildNumber = DeviceInfo.getBuildNumber();
 
 // iOS: "89"
-// Android: 4
+// Android: "4"
 // Windows: ?
 ```
-
-**Notes**
-
-> There is a type inconsistency: Android return an integer instead of the documented string.
 
 ---
 

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -328,14 +328,14 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     constants.put("appVersion", "not available");
     constants.put("appName", "not available");
     constants.put("buildVersion", "not available");
-    constants.put("buildNumber", 0);
+    constants.put("buildNumber", "0");
 
     try {
       PackageInfo packageInfo = packageManager.getPackageInfo(packageName, 0);
       PackageInfo info = packageManager.getPackageInfo(packageName, 0);
       String applicationName = this.reactContext.getApplicationInfo().loadLabel(this.reactContext.getPackageManager()).toString();
       constants.put("appVersion", info.versionName);
-      constants.put("buildNumber", info.versionCode);
+      constants.put("buildNumber", Integer.toString(info.versionCode));
       constants.put("firstInstallTime", info.firstInstallTime);
       constants.put("lastUpdateTime", info.lastUpdateTime);
       constants.put("appName", applicationName);


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixed issue #214

<!-- OR, if you're implementing a new feature: -->

Parse the return integer from PackageManager in to a string, also returns "0" by default instead of 0. 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [x] I mentioned this change in `CHANGELOG.md`
* [x] I updated the typings files (`deviceinfo.d.ts`, `deviceinfo.js.flow`)
* [x] I updated the web polyfill (`web/index.js`)
