### PR TITLE
chore: fix pointer types and macro usage based on XCode warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 1.6.1
  * fix: fix building issue on tvOS / headers on iOS (https://github.com/react-native-community/react-native-device-info/pull/652)
+ * chore: fix pointer types in iOS build (https://github.com/react-native-community/react-native-device-info/pull/649)
 
 ### 1.6.0
  * feat: implement hasSystemFeature() method for Android devices (https://github.com/react-native-community/react-native-device-info/pull/646)

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -38,7 +38,7 @@ typedef NS_ENUM(NSInteger, DeviceType) {
 
 @synthesize isEmulator;
 
-RCT_EXPORT_MODULE(RNDeviceInfo);
+RCT_EXPORT_MODULE();
 
 + (BOOL)requiresMainQueueSetup
 {
@@ -244,7 +244,7 @@ RCT_EXPORT_MODULE(RNDeviceInfo);
     return language;
 }
 
-- (NSString*) preferredLocales
+- (NSArray<NSString *> *) preferredLocales
 {
     return [NSLocale preferredLanguages];
 }
@@ -342,7 +342,7 @@ RCT_EXPORT_MODULE(RNDeviceInfo);
 
 - (NSString *)getCPUType {
     /* https://stackoverflow.com/questions/19859388/how-can-i-get-the-ios-device-cpu-architecture-in-runtime */
-    NXArchInfo *info = NXGetLocalArchInfo();
+    const NXArchInfo *info = NXGetLocalArchInfo();
     NSString *typeOfCpu = [NSString stringWithUTF8String:info->description];
     return typeOfCpu;
 }


### PR DESCRIPTION

## Description

Fix iOS build issues - there were two incompatible pointer types, and we were not following convention in a macro usage

This makes it so when you include this module it builds cleanly

This should be backwards compatible and just a patch version

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`deviceinfo.d.ts`, `deviceinfo.js.flow`)
* [ ] I updated the web polyfill (`web/index.js`)
