### PR TITLE
fix: building issue on tvOS / header on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Next
 
+### 1.6.1
+ * fix: fix building issue on tvOS / headers on iOS (https://github.com/react-native-community/react-native-device-info/pull/652)
+
 ### 1.6.0
  * feat: implement hasSystemFeature() method for Android devices (https://github.com/react-native-community/react-native-device-info/pull/646)
 

--- a/ios/RNDeviceInfo.xcodeproj/project.pbxproj
+++ b/ios/RNDeviceInfo.xcodeproj/project.pbxproj
@@ -157,6 +157,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = DA5891CF1BA9A9FC002B4DB2;
@@ -324,6 +325,14 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(BUILT_PRODUCTS_DIR)/usr/local/include",
+					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/node_modules/react-native/React/**",
+					"$(SRCROOT)/../react-native/React/**",
+					"$(SRCROOT)/../../../node_modules/react-native/React/**",
+				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -351,6 +360,14 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(BUILT_PRODUCTS_DIR)/usr/local/include",
+					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/node_modules/react-native/React/**",
+					"$(SRCROOT)/../react-native/React/**",
+					"$(SRCROOT)/../../../node_modules/react-native/React/**",
+				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;

--- a/ios/RNDeviceInfo.xcodeproj/project.pbxproj
+++ b/ios/RNDeviceInfo.xcodeproj/project.pbxproj
@@ -228,6 +228,14 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+                                HEADER_SEARCH_PATHS = (
+                                        "$(inherited)",
+                                        "$(BUILT_PRODUCTS_DIR)/usr/local/include",
+                                        "$(SRCROOT)/../../React/**",
+                                        "$(SRCROOT)/node_modules/react-native/React/**",
+                                        "$(SRCROOT)/../react-native/React/**",
+                                        "$(SRCROOT)/../../../node_modules/react-native/React/**",
+                                );
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -264,6 +272,14 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+                                HEADER_SEARCH_PATHS = (
+                                        "$(inherited)",
+                                        "$(BUILT_PRODUCTS_DIR)/usr/local/include",
+                                        "$(SRCROOT)/../../React/**",
+                                        "$(SRCROOT)/node_modules/react-native/React/**",
+                                        "$(SRCROOT)/../react-native/React/**",
+                                        "$(SRCROOT)/../../../node_modules/react-native/React/**",
+                                );
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -477,7 +477,7 @@ RCT_EXPORT_METHOD(isPinOrFingerprintSet:(RCTResponseSenderBlock)callback)
                    "You need to enable monitoring with `[UIDevice currentDevice].batteryMonitoringEnabled = TRUE`");
     }
 #endif
-#if RCT_DEV && (TARGET_OS_TV || TARGET_IPHONE_SIMULATOR)
+#if RCT_DEV && TARGET_IPHONE_SIMULATOR && !TARGET_OS_TV
     if ([UIDevice currentDevice].batteryState == UIDeviceBatteryStateUnknown) {
         RCTLogWarn(@"Battery state `unknown` and monitoring disabled, this is normal for simulators and tvOS.");
     }


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description
Fixed a build issue on tvOS in xcode 10.2. tvOS Header Search Paths were missing and couldn't find the `<React/RCTUtils.h>`. Also, `batteryState` is not available for tvOS and xcode failed to build, so I updated the if statement.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [ ] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`deviceinfo.d.ts`, `deviceinfo.js.flow`)
* [ ] I updated the dummy web/test polyfill (`default/index.js`)
* [ ] I added a sample use of the API (`example/App.js`)
