### PR TITLE
fix: added v to tag name in podspec

### DIFF
--- a/RNDeviceInfo.podspec
+++ b/RNDeviceInfo.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '10.0'
 
-  s.source       = { :git => "https://github.com/react-native-community/react-native-device-info.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/react-native-community/react-native-device-info.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'


### PR DESCRIPTION
When missing the v for the tag name, directly referencing the podspec file can result in a "tag not found" error when doing a pod install.


## Description

Fixed issue #659 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
| Windows |   ❌     |

## Checklist




* [x] Ran pod install and was able to build and archive the project

