### PR TITLE
types: make the typescript location / power returns specific

### DIFF
--- a/deviceinfo.d.ts
+++ b/deviceinfo.d.ts
@@ -3,6 +3,19 @@
 
 export type DeviceType = 'Handset' | 'Tablet' | 'Tv' | 'Unknown';
 
+export type BatteryState = 'unknown' | 'unplugged' | 'charging' | 'full';
+
+export interface PowerState {
+  batteryLevel: number;
+  batteryState: BatteryState;
+  lowPowerMode: boolean;
+  [key: string]: any;
+}
+
+export interface LocationProviderInfo {
+  [key: string]: boolean;
+}
+
 declare const _default: {
   getUniqueID: () => string;
   getManufacturer: () => string;
@@ -29,7 +42,9 @@ declare const _default: {
   isTablet: () => boolean;
   getFontScale: () => number;
   is24Hour: () => boolean;
-  isPinOrFingerprintSet(): (cb: (isPinOrFingerprintSet: boolean) => void) => void;
+  isPinOrFingerprintSet(): (
+    cb: (isPinOrFingerprintSet: boolean) => void
+  ) => void;
   hasNotch: () => boolean;
   getFirstInstallTime: () => number;
   getLastUpdateTime: () => number;
@@ -45,7 +60,7 @@ declare const _default: {
   getTotalDiskCapacity: () => number;
   getFreeDiskStorage: () => number;
   getBatteryLevel: () => Promise<number>;
-  getPowerState: () => Promise<object>;
+  getPowerState: () => Promise<PowerState>;
   isBatteryCharging: () => Promise<boolean>;
   isLandscape: () => boolean;
   isAirPlaneMode: () => Promise<boolean>;
@@ -56,7 +71,7 @@ declare const _default: {
   hasSystemFeature: (feature: string) => Promise<boolean>;
   getSystemAvailableFeatures: () => Promise<string[]>;
   isLocationEnabled: () => Promise<boolean>;
-  getAvailableLocationProviders: () => Promise<Object>;
+  getAvailableLocationProviders: () => Promise<LocationProviderInfo>;
 };
 
 export default _default;


### PR DESCRIPTION
These are just type fixes from a couple recent PRs

I'm still getting better at Typescript so I didn't realize these would be problematic as submitted until I attempted to use them in a project and there were complaints about the return values.

Since they have known types from the native code, I made them specific.

I don't know enough about flow to do those but would love if someone did, or maybe we can leave them generic.

Also, I am not sure about the breaking nature of this or not - but I think if we are going from less-specific to more-specific it shouldn't break anyone?