### PR TITLE
fix: use non-deprecated APIs where available in `getFreeDiskStorage()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Release Notes
 
 ### Next
+* fix: `getFreeDiskStorage()` to use `StatFs` methods that return `long` instead of `int` (which are now deprecated)
 
 ### 2.0.0
 * breaking: no functional change from 1.8.0, but isLocationEnabled requires minCompileSdk 28

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -277,7 +277,18 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   public BigInteger getFreeDiskStorage() {
     try {
       StatFs external = new StatFs(Environment.getExternalStorageDirectory().getAbsolutePath());
-      return BigInteger.valueOf(external.getAvailableBlocks()).multiply(BigInteger.valueOf(external.getBlockSize()));
+      long availableBlocks;
+      long blockSize;
+
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
+        availableBlocks = external.getAvailableBlocks();
+        blockSize = external.getBlockSize();
+      } else {
+        availableBlocks = external.getAvailableBlocksLong();
+        blockSize = external.getBlockSizeLong();
+      }
+
+      return BigInteger.valueOf(availableBlocks).multiply(BigInteger.valueOf(blockSize));
     } catch (Exception e) {
       e.printStackTrace();
     }


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

This PR switches two `StatFs` method calls in `getFreeDiskStorage()` to use their newer, `long`, variants when available (instead of older, deprecated versions). 

Fixed issue #N/A

<!-- OR, if you're implementing a new feature: -->

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅ (n/a)     |
| Android |    ✅     |
| Windows |    ✅ (n/a)     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] ~I added the documentation in `README.md`~
* [x] I mentioned this change in `CHANGELOG.md`
* [ ] ~I updated the typings files (`deviceinfo.d.ts`, `deviceinfo.js.flow`)~
* [ ] ~I updated the dummy web/test polyfill (`default/index.js`)~
* [ ] ~I added a sample use of the API (`example/App.js`)~