### PR TITLE
perf(Android): getConstants() in thread to parallelize load, speed up for most

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceInfo.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceInfo.java
@@ -11,12 +11,21 @@ import java.util.Collections;
 import java.util.List;
 
 public class RNDeviceInfo implements ReactPackage {
+  private boolean mLoadConstantsAsynchronously;
+
+  public RNDeviceInfo() {
+    this(false);
+  }
+
+  public RNDeviceInfo(boolean loadConstantsAsynchronously) {
+    mLoadConstantsAsynchronously = loadConstantsAsynchronously;
+  }
 
   @Override
   public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
     List<NativeModule> modules = new ArrayList<>();
 
-    modules.add(new RNDeviceModule(reactContext));
+    modules.add(new RNDeviceModule(reactContext, mLoadConstantsAsynchronously));
 
     return modules;
   }


### PR DESCRIPTION
## Description

RNDeviceModule.getConstants() can take a lot of time (~300ms on a Galaxy S7), so try to run it as soon as possible in the background so that by the time it gets called, the constants have already been calculated and we can just return the map.

## Checklist

<!-- Check completed item: [X] -->

* [X] I have tested this on a device/simulator for each compatible OS
* [X] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
