### PR TITLE
fix(Android): Avoid NullpointerException on install referer listener

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceReceiver.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceReceiver.java
@@ -10,7 +10,7 @@ public class RNDeviceReceiver extends BroadcastReceiver {
   @Override
   public void onReceive(Context context, Intent intent) {
     String action = intent.getAction();
-    if (action.equals("com.android.vending.INSTALL_REFERRER")) {
+    if ("com.android.vending.INSTALL_REFERRER".equals(action)) {
       SharedPreferences sharedPref = context.getSharedPreferences("react-native-device-info", Context.MODE_PRIVATE);
       SharedPreferences.Editor editor = sharedPref.edit();
       editor.putString("installReferrer", intent.getStringExtra("referrer"));


### PR DESCRIPTION
action is Nullable, so we call equals from action is not safe

```
java.lang.RuntimeException · Unable to start receiver com.learnium.RNDeviceInfo.RNDeviceReceiver: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.String.equals(java.lang.Object)' on a null object reference
```

<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixed issue #<issue-number>

<!-- OR, if you're implementing a new feature: -->

Added `yourNewMethodName()` that allows ...

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |
| Windows |    ✅❌     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [x] I mentioned this change in `CHANGELOG.md`
* [x] I updated the typings files (`deviceinfo.d.ts`, `deviceinfo.js.flow`)
* [x] I updated the dummy web/test polyfill (`default/index.js`)
* [x] I added a sample use of the API (`example/App.js`)
