### PR TITLE
Readme: Clarify location of RNDeviceInfo.xcodeproj

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ In XCode, in the project navigator:
 
 * Right click _Libraries_
 * Add Files to _[your project's name]_
-* Go to `node_modules/react-native-device-info`
-* Add the `.xcodeproj` file
+* Go to `node_modules/react-native-device-info/ios`
+* Add the file `RNDeviceInfo.xcodeproj`
 
 In XCode, in the project navigator, select your project.
 


### PR DESCRIPTION
Under the iOS "Manual Linking" section, there is no file with the extension `.xcodeproj` in the location specified in the README. I have updated this section to specify the correct location of this file.