### PR TITLE
docs: Update Podfile contents under Linking -> iOS (via CocoaPods)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,31 @@ You still need to run `pod install` after running the above link command inside 
 <details>
     <summary>iOS (via CocoaPods)</summary>
 
-Add the following line to your build targets in your `Podfile`
+Add the following lines to your build targets in your `Podfile`
 
-`pod 'RNDeviceInfo', :path => '../node_modules/react-native-device-info'`
+```
+pod 'React', :path => '../node_modules/react-native'
+
+# Explicitly include Yoga if you are using RN >= 0.42.0
+pod 'yoga', :path => '../node_modules/react-native/ReactCommon/yoga'
+
+pod 'RNDeviceInfo', :path => '../node_modules/react-native-device-info'
+  
+# React-Native is not great about React double-including from the Podfile
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    if target.name == "React"
+      target.remove_from_project
+    end
+
+    # It removes React & Yoga from the Pods project, as it is already included in the main project.
+    targets_to_ignore = %w(React yoga)
+    if targets_to_ignore.include? target.name
+      target.remove_from_project
+    end
+  end
+end
+```
 
 Then run `pod install`
 


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixed issue #691 

<!-- OR, if you're implementing a new feature: -->

Added a few more contents to the Podfile to result in a successful build.

Adding `pod 'React', :path => '../node_modules/react-native'`
prevents CocoaPods from installing a "React" Pod in the `ios/Pods` directory.

Not adding this line results in multiple versions of "React" being installed in the same project (one in `/node_modules` and the other in `ios/Pods`) which probably results in a conflict.