### PR TITLE
Constraint gcm version to 16.1.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    implementation "com.google.android.gms:play-services-gcm:${safeExtGet('googlePlayServicesVersion', '+')}"
+    implementation "com.google.android.gms:play-services-gcm:${safeExtGet('googlePlayServicesVersion', '16.1.0')}"
     //noinspection GradleCompatible
     implementation "com.android.support:appcompat-v7:${safeExtGet('supportLibVersion', '28.0.0')}"
     implementation "com.android.support:support-v4:${safeExtGet('supportLibVersion', '28.0.0')}"


### PR DESCRIPTION
## Description

With the latest firebase/gcm release (https://developers.google.com/android/guides/releases), the latest version (`+`) now brings in androidx dependencies. react-native won't be ready for androidx until 0.60 so constraint the gcm version to 16.1.0 (the latest pre-androidx version)