### PR TITLE
docs(README): Clarify the new changes regarding loading constants async

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ or using yarn:
 yarn add react-native-device-info
 ```
 
+> ⚠️ As of version 2.1.1 the package can be loaded async to improve start up time on Android [Refer to this PR for more information](https://github.com/react-native-community/react-native-device-info/pull/680)
+```java
+    @Override
+    public List<ReactPackage> createAdditionalReactPackages() {
+        return Arrays.<ReactPackage>asList(
+            new RNDeviceInfo(true), // Pass true to load the constants asynchronously on start up, default is false
+        );
+    }
+```
+
 > ⚠️ If you are on React Native > 0.47, you must use version 0.11.0 of this library or higher
 
 ## Linking


### PR DESCRIPTION
## Description

This PR adds a notice regarding the changes in: https://github.com/react-native-community/react-native-device-info/pull/680

The main reason I left it under the Installation header is because I am afraid people might miss it when using automatic linking.
