### PR TITLE
Fix crash for API lower than 23

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -507,7 +507,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     constants.put("product", Build.PRODUCT);
     constants.put("tags", Build.TAGS);
     constants.put("type", Build.TYPE);
-    if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+    if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       constants.put("baseOS", Build.VERSION.BASE_OS);
       constants.put("previewSdkInt", Build.VERSION.PREVIEW_SDK_INT);
       constants.put("securityPatch", Build.VERSION.SECURITY_PATCH);


### PR DESCRIPTION
PREVIEW_SDK_INT was introduced in API level 23 so we should check for Marshmallow not for Lollipop

