### PR TITLE
Fix: isTablet() on Android uses smallest-width-dp when available

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -186,8 +186,13 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
       return DeviceType.TV;
     }
 
+    return  getDeviceTypeFromPhysicalSize(reactContext);
+  }
+
+  private static DeviceType getDeviceTypeFromPhysicalSize(ReactApplicationContext reactContext) {
     // Find the current window manager, if none is found we can't measure the device physical size.
     WindowManager windowManager = (WindowManager) reactContext.getSystemService(Context.WINDOW_SERVICE);
+
     if (windowManager == null) {
       return DeviceType.UNKNOWN;
     }

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -186,7 +186,25 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
       return DeviceType.TV;
     }
 
+    DeviceType deviceTypeFromConfig = getDeviceTypeFromResourceConfiguration(reactContext);
+
+    if (deviceTypeFromConfig != null && deviceTypeFromConfig != DeviceType.UNKNOWN) {
+      return deviceTypeFromConfig;
+    }
+
     return  getDeviceTypeFromPhysicalSize(reactContext);
+  }
+
+  // Use `smallestScreenWidthDp` to determine the screen size
+  // https://android-developers.googleblog.com/2011/07/new-tools-for-managing-screen-sizes.html
+  private  static  DeviceType getDeviceTypeFromResourceConfiguration(ReactApplicationContext reactContext) {
+    int smallestScreenWidthDp = reactContext.getResources().getConfiguration().smallestScreenWidthDp;
+
+    if (smallestScreenWidthDp == Configuration.SMALLEST_SCREEN_WIDTH_DP_UNDEFINED) {
+      return  DeviceType.UNKNOWN;
+    }
+
+    return  smallestScreenWidthDp >= 600 ? DeviceType.TABLET : DeviceType.HANDSET;
   }
 
   private static DeviceType getDeviceTypeFromPhysicalSize(ReactApplicationContext reactContext) {


### PR DESCRIPTION
## Description

Fixed issue #729 

As described in the Issue #729, the logic used to determine if the `DeviceType` is a Tablet or Handset is now based on the **` smallestScreenWidthDp`**; With fallback on the previous *physical size* based logic in cases when the `smallestScreenWidthDp` is not defined.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

* [X] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`deviceinfo.d.ts`, `deviceinfo.js.flow`)
* [ ] I updated the dummy web/test polyfill (`default/index.js`)
* [ ] I added a sample use of the API (`example/App.js`)
