### PR TITLE
Add `@ReactModule` annotation and `NAME` constant

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -41,6 +41,7 @@ import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.module.annotations.ReactModule;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -57,7 +58,9 @@ import java.util.concurrent.ExecutionException;
 
 import javax.annotation.Nullable;
 
+@ReactModule(name = RNDeviceModule.NAME)
 public class RNDeviceModule extends ReactContextBaseJavaModule {
+  public static final String NAME = "RNDeviceInfo";
 
   ReactApplicationContext reactContext;
 
@@ -87,7 +90,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
 
   @Override
   public String getName() {
-    return "RNDeviceInfo";
+    return NAME;
   }
 
   private WifiInfo getWifiInfo() {


### PR DESCRIPTION
## Description

Add `@ReactModule` annotation and `NAME` constant. This will eventually be used by TurboModules annotation processor.

## Compatibility

N/A

## Checklist

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`deviceinfo.d.ts`, `deviceinfo.js.flow`)
* [ ] I updated the dummy web/test polyfill (`default/index.js`)
* [ ] I added a sample use of the API (`example/App.js`)
