### PR TITLE
Remove obsolete gradle dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Release Notes
 
 ### Next
+* chore: Remove obsolete gradle dependencies (https://github.com/react-native-community/react-native-device-info/pull/746)
 
 ### 2.3.2
 * fix: load module async by default with option to load sync (https://github.com/react-native-community/react-native-device-info/pull/741)

--- a/README.md
+++ b/README.md
@@ -47,11 +47,6 @@ AndroidX is supported in a non-breaking / backwards-compatible way by using over
   ext {
     // dependency versions
     googlePlayServicesVersion = "17.0.0" // default: "16.1.0" - pre-AndroidX, override for AndroidX
-    compileSdkVersion = "28" // default: 28 (28 is required for AndroidX)
-    targetSdkVersion = "28" // default: 28 (28 is required for AndroidX)
-    supportLibVersion = '1.0.2' // Use '28.0.0' or don't specify for old libraries, '1.0.2' or similar for AndroidX
-    mediaCompatVersion = '1.0.1' // Do not specify if using old libraries, specify '1.0.1' or similar for androidx.media:media dependency
-    supportV4Version = '1.0.0' // Do not specify if using old libraries, specify '1.0.0' or similar for androidx.legacy:legacy-support-v4 dependency
   }
 ...
 ```
@@ -1500,14 +1495,14 @@ When installing or using `react-native-device-info`, you may encounter the follo
 <details>
   <summary>[android] - Unable to merge dex / Multiple dex files / Problems with `com.google.android.gms`</summary>
 
-`react-native-device-info` uses `com.google.android.gms:play-services-gcm` to provide [getInstance()][#getinstance].
+`react-native-device-info` uses `com.google.android.gms:play-services-iid` to provide [getInstance()][#getinstance].
 This can lead to conflicts when building the Android application.
 
-If you're using a different version of `com.google.android.gms:play-services-gcm` in your app, you can define the
+If you're using a different version of `com.google.android.gms:play-services-iid` in your app, which may be a subdependency of another google-play-services library, you can define the
 `googlePlayServicesVersion` gradle variable in your `build.gradle` file to tell `react-native-device-info` what version
 it should require. See the example project included here for a sample.
 
-If you're using a different library that conflicts with `com.google.android.gms:play-services-gcm`, and you are certain you know what you are doing such that you will avoid version conflicts, you can simply
+If you're using a different library that conflicts with `com.google.android.gms:play-services-iid`, and you are certain you know what you are doing such that you will avoid version conflicts, you can simply
 ignore this dependency in your gradle file:
 
 ```groovy

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,17 +41,6 @@ repositories {
 
 dependencies {
     // Use either AndroidX library names or old/support library names based on major version of support lib
-    def supportLibVersion = safeExtGet('supportLibVersion', '28.0.0')
-    def supportLibMajorVersion = supportLibVersion.split('\\.')[0] as int
-    def appCompatLibName =  (supportLibMajorVersion < 20) ? "androidx.appcompat:appcompat" : "com.android.support:appcompat-v7"
-    def supportV4LibName =  (supportLibMajorVersion < 20) ? "androidx.legacy:legacy-support-v4" : "com.android.support:support-v4"
-    def supportV4Version = safeExtGet('supportV4Version', safeExtGet('supportLibVersion', '28.0.0'))
-    def mediaCompatLibName =  (supportLibMajorVersion < 20) ? "androidx.media:media" : "com.android.support:support-media-compat"
-    def mediaCompatVersion = safeExtGet('mediaCompatVersion', safeExtGet('supportLibVersion', '28.0.0'))
-
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    implementation "com.google.android.gms:play-services-gcm:${safeExtGet('googlePlayServicesVersion', '16.1.0')}"
-    implementation "$appCompatLibName:$supportLibVersion"
-    implementation "$supportV4LibName:$supportV4Version"
-    implementation "$mediaCompatLibName:$mediaCompatVersion"
+    implementation "com.google.android.gms:play-services-iid:${safeExtGet('googlePlayServicesVersion', '16.1.0')}"
 }

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -510,7 +510,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
         constants.put("instanceId", com.google.android.gms.iid.InstanceID.getInstance(this.reactContext).getId());
       }
     } catch (ClassNotFoundException e) {
-      constants.put("instanceId", "N/A: Add com.google.android.gms:play-services-gcm to your project.");
+      constants.put("instanceId", "N/A: Add com.google.android.gms:play-services-iid to your project.");
     }
     constants.put("serialNumber", Build.SERIAL);
     constants.put("deviceName", deviceName);

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,7 +6,6 @@ buildscript {
         minSdkVersion = 16
         compileSdkVersion = 28
         targetSdkVersion = 28
-        supportLibVersion = "28.0.0"
     }
     repositories {
         google()

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -16,6 +16,3 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-
-android.useAndroidX=true
-android.enableJetifier=true


### PR DESCRIPTION
## Description

This pull request proposes two changes to the dependencies defined in the native Android code of react-native-device-info.

1. Remove the direct dependency on the Android support library or AndroidX
The native Android code does not utilise any of the functionalities provided by these libraries directly. SupportLib/AndroidX is a dependency of all play-services libraries but you do not need to specify them directly. They were added in #590 to fix some kind of linting problem which I'm unable to reproduce. So that makes the specification here obsolete.
2. Replace the gcm dependency by a direct dependency on `play-services-iid`
The instance id interface that `react-native-device-info` uses for the unique device id on Android is actually part of `com.google.android.gms:play-services-iid` which is a dependency of 
`com.google.android.gms:play-services-gcm` that is currently used. Using the right dependency here will decrease the size of the imported code for everyone using `react-native-device-info`. 
I do not believe this to be a breaking change since the version of both `gcm` and `iid` is the same. If users of the package use any `com.google.android.gms:play-services-*` libraries gradle's depedency resolution should make sure the change is dealt with correctly.

To test this PR I pointed the example app to this branch on my fork but obviously I have not committed these changes. Maybe it would be good to put the package itself in a different subdirectory so that the example app can directly import the local sources instead of using the repository as dependency.

## Compatibility
Not applicable. 

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [x] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`deviceinfo.d.ts`, `deviceinfo.js.flow`)
* [ ] I updated the dummy web/test polyfill (`default/index.js`)
* [ ] I added a sample use of the API (`example/App.js`)
