### PR TITLE
removing RNDeviceReceiver by default and updated Readme.md for the same.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Release Notes
 
 ### Next
+* breaking(Android): removing RNDeviceReceiver by default. (https://github.com/react-native-community/react-native-device-info/pull/750)
 
 ### 2.3.2
 * fix: load module async by default with option to load sync (https://github.com/react-native-community/react-native-device-info/pull/741)

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ import DeviceInfo from 'react-native-device-info';
 | [getHost()](#gethost)                                             | `string`            |  ❌  |   ✅    |   ❌    | ?      |
 | [getIPAddress()](#getipaddress)                                   | `Promise<string>`   |  ✅  |   ✅    |   ✅    | 0.12.0 |
 | [getIncremental()](#getincremental)                               | `string`            |  ❌  |   ✅    |   ❌    | ?      |
-| [getInstallReferrer()](#getinstallreferrer)                       | `string`            |  ❌  |   ✅    |   ❌    | 0.19.0 |
+| [getInstallReferrer()](#getinstallreferrer)                       | `string`            |  ❌  |   ✅⚠️    |   ❌    | 0.19.0 |
 | [getInstanceID()](#getinstanceid)                                 | `string`            |  ❌  |   ✅    |   ❌    | ?      |
 | [getLastUpdateTime()](#getlastupdatetime)                         | `number`            |  ❌  |   ✅    |   ❌    | 0.12.0 |
 | [getMACAddress()](#getmacaddress)                                 | `Promise<string>`   |  ✅  |   ✅    |   ❌    | 0.12.0 |
@@ -784,6 +784,23 @@ const referrer = DeviceInfo.getInstallReferrer();
 
 // If the app was installed from https://play.google.com/store/apps/details?id=com.myapp&referrer=my_install_referrer
 // the result will be "my_install_referrer"
+```
+
+**Notes**
+> ⚠️ **ANDROID** - *Need to add receiver in AndroidManifest.xml*
+```xml
+<application>
+    ...
+    ...
+    <receiver
+        android:name="com.learnium.RNDeviceInfo.RNDeviceReceiver"
+        android:enabled="true"
+        android:exported="true">
+        <intent-filter>
+            <action android:name="com.android.vending.INSTALL_REFERRER" />
+        </intent-filter>
+    </receiver>
+</application>
 ```
 
 ---

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,16 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.learnium.RNDeviceInfo">
-          
-    <application>
-        <receiver
-            android:name="com.learnium.RNDeviceInfo.RNDeviceReceiver"
-            android:enabled="true"
-            android:exported="true"
-        >
-            <intent-filter>
-                <action android:name="com.android.vending.INSTALL_REFERRER" />
-            </intent-filter>
-        </receiver>
-    </application>
-
 </manifest>

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -21,6 +21,14 @@
         </intent-filter>
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+      <receiver
+        android:name="com.learnium.RNDeviceInfo.RNDeviceReceiver"
+        android:enabled="true"
+        android:exported="true">
+        <intent-filter>
+            <action android:name="com.android.vending.INSTALL_REFERRER" />
+        </intent-filter>
+    </receiver>
     </application>
 
 </manifest>


### PR DESCRIPTION
**getInstallReferrer** is not a very used function, hence it doesn't make sense to Add RNDeviceReceiver by default.

In this PR i have removed the receiver entry from AndroidManifest.xml and updated **README.md** regarding the same.

## Description

Fixed issue:
Removing unnecessary broadcast receiver.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [x ] I have tested this on a device/simulator for each compatible OS
* [ x] I added the documentation in `README.md`
* [ x] I mentioned this change in `CHANGELOG.md`
* [ x] I updated the typings files (`deviceinfo.d.ts`, `deviceinfo.js.flow`)
* [ x] I updated the dummy web/test polyfill (`default/index.js`)
* [ x] I added a sample use of the API (`example/App.js`)
