### PR TITLE
Mention that `getUniqueID()` can be different in app extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1135,7 +1135,8 @@ const uniqueId = DeviceInfo.getUniqueID();
 
 **Notes**
 
-> * iOS: This is [`IDFV`](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor) or a random string if IDFV is unavaliable. Once UID is generated it is stored in iOS Keychain and NSUserDefaults. So it would stay the same even if you delete the app or reset IDFV. You can *carefully* consider it a persistent, cross-install unique ID. It can be changed only in case someone manually override values in Keychain/NSUserDefaults or if Apple would change Keychain and NSUserDefaults implementations
+> * iOS: This is [`IDFV`](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor) or a random string if IDFV is unavaliable. Once UID is generated it is stored in iOS Keychain and NSUserDefaults. So it would stay the same even if you delete the app or reset IDFV. You can *carefully* consider it a persistent, cross-install unique ID. It can be changed only in case someone manually override values in Keychain/NSUserDefaults or if Apple would change Keychain and NSUserDefaults implementations.
+> Beware: The IDFV is calculated using your bundle identifier and thus will be different in app extensions.
 > * android: Prior to Oreo, this id ([ANDROID_ID](https://developer.android.com/reference/android/provider/Settings.Secure.html#ANDROID_ID)) will always be the same once you set up your phone.
 
 ---


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

I stumbled over this when implementing a share extension, which has a different bundle identifier than my main app.
Since I used `getUniqueID()` to construct a User-Agent that needed to be stable for Authentication purposes, this broke auth for me.

* [ ] I have tested this on a device/simulator for each compatible OS
* [X] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`deviceinfo.d.ts`, `deviceinfo.js.flow`)
* [ ] I updated the dummy web/test polyfill (`default/index.js`)
* [ ] I added a sample use of the API (`example/App.js`)