### PR TITLE
Fix bug where getModel return undefined because deviceId is undefined

### DIFF
--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -541,9 +541,9 @@ export async function getModel() {
   if (!model) {
     if (OS === 'ios') {
       let deviceName;
-      let device = await RNDeviceInfo.getDeviceId();
+      let deviceId = await RNDeviceInfo.getDeviceId();
       if (deviceId) {
-        deviceName = deviceNamesByCode[device];
+        deviceName = deviceNamesByCode[deviceId];
         if (!deviceName) {
           // Not found on database. At least guess main device type from string contents:
           if (device.startsWith('iPod')) {


### PR DESCRIPTION
## Description

Can't find a related issue, but when testing the RC I found that `deviceId` in `getModel` would be undefined because of a inconsistency of the deviceId const in `getModel`.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

All others seem unrelated ;)

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`deviceinfo.d.ts`, `deviceinfo.js.flow`)
* [ ] I updated the dummy web/test polyfill (`default/index.js`)
* [ ] I added a sample use of the API (`example/App.js`)
