### PR TITLE
feat(events): Add support to Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Every API returns a Promise but also has a corresponding API with 'Sync' on the 
 | [getMaxMemory()](#getmaxmemory)                                   | `Promise<number>`   |  ❌  |   ✅    |   ✅    |
 | [getModel()](#getmodel)                                           | `Promise<string>`   |  ✅  |   ✅    |   ✅    |
 | [getPhoneNumber()](#getphonenumber)                               | `Promise<string>`   |  ❌  |   ✅    |   ❌    |
-| [getPowerState()](#getpowerstate)                                 | `Promise<object>`   |  ✅  |   ❌    |   ❌    |
+| [getPowerState()](#getpowerstate)                                 | `Promise<object>`   |  ✅  |   ✅    |   ❌    |
 | [getProduct()](#getproduct)                                       | `Promise<string>`   |  ❌  |   ✅    |   ❌    |
 | [getPreviewSdkInt()](#getPreviewSdkInt)                           | `Promise<number>`   |  ❌  |   ✅    |   ❌    |
 | [getReadableVersion()](#getreadableversion)                       | `Promise<string>`   |  ✅  |   ✅    |   ✅    |

--- a/README.md
+++ b/README.md
@@ -1415,7 +1415,12 @@ deviceInfoEmitter.addListener('RNDeviceInfo_batteryLevelDidChange', level => {
 
 ### RNDeviceInfo_batteryLevelIsLow
 
-Fired when the battery drops below 20%.
+Fired when the battery drops is considered low
+
+| Platform | Percentage |
+| -------- | ---------- |
+| iOS      | 20         |
+| Android  | 15         |
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -1394,7 +1394,7 @@ DeviceInfo.getAvailableLocationProviders().then(providers => {
 
 ## Events
 
-Currently iOS-only.
+Currently iOS & Android only.
 
 ### RNDeviceInfo_batteryLevelDidChange
 

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -56,6 +56,8 @@ import java.math.BigInteger;
 
 import javax.annotation.Nonnull;
 
+import static android.os.BatteryManager.BATTERY_STATUS_CHARGING;
+import static android.os.BatteryManager.BATTERY_STATUS_FULL;
 import static android.provider.Settings.Secure.getString;
 
 @ReactModule(name = RNDeviceModule.NAME)
@@ -99,7 +101,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
         if(mLastBatteryLevel != batteryLevel) {
             sendEvent(getReactApplicationContext(), "RNDeviceInfo_batteryLevelDidChange", batteryLevel);
 
-          if(batteryLevel < .2) {
+          if(batteryLevel <= .15) {
             sendEvent(getReactApplicationContext(), "RNDeviceInfo_batteryLevelIsLow", batteryLevel);
           }
 
@@ -393,7 +395,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     if (batteryStatus != null) {
       status = batteryStatus.getIntExtra(BatteryManager.EXTRA_STATUS, -1);
     }
-    return status == BatteryManager.BATTERY_STATUS_CHARGING;
+    return status == BATTERY_STATUS_CHARGING;
   }
   @ReactMethod
   public void isBatteryCharging(Promise p) { p.resolve(isBatteryChargingSync()); }
@@ -414,7 +416,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod(isBlockingSynchronousMethod = true)
-  public float getBatteryLevelSync() {
+  public double getBatteryLevelSync() {
     Intent intent = getReactApplicationContext().registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
     WritableMap powerState = getPowerStateFromIntent(intent);
 
@@ -886,9 +888,9 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
 
     if(isPlugged == 0) {
       batteryState = "unplugged";
-    } else if(status == 2) {
+    } else if(status == BATTERY_STATUS_CHARGING) {
       batteryState = "charging";
-    } else if(status == 5) {
+    } else if(status == BATTERY_STATUS_FULL) {
       batteryState = "full";
     }
 

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -409,11 +409,14 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void getUsedMemory(Promise p) { p.resolve(getUsedMemorySync()); }
 
-  @ReactMethod
-  public WritableMap getPowerState() {
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public WritableMap getPowerStateSync() {
     Intent intent = getReactApplicationContext().registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
     return getPowerStateFromIntent(intent);
   }
+
+  @ReactMethod
+  public void getPowerState(Promise p) { p.resolve(getPowerStateSync()); }
 
   @ReactMethod(isBlockingSynchronousMethod = true)
   public double getBatteryLevelSync() {

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -1493,7 +1493,7 @@ export async function getPowerState() {
 }
 
 export function getPowerStateSync() {
-  if (OS === 'ios') {
+  if (OS === 'ios' || OS === 'android') {
     return RNDeviceInfo.getPowerStateSync();
   }
   return {};

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -1486,7 +1486,7 @@ export function getBatteryLevelSync() {
 }
 
 export async function getPowerState() {
-  if (OS === 'ios') {
+  if (OS === 'ios' || OS === 'android') {
     return RNDeviceInfo.getPowerState();
   }
   return Promise.resolve({});


### PR DESCRIPTION
## Description

Added support for the following events on Android

- RNDeviceInfo_batteryLevelDidChange
- RNDeviceInfo_batteryLevelIsLow
- RNDeviceInfo_powerStateDidChange


## Checklist

<!-- Check completed item: [X] -->

* [X] I have tested this on a device/simulator for each compatible OS
* [X] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`deviceinfo.d.ts`, `deviceinfo.js.flow`)
* [ ] I updated the dummy web/test polyfill (`default/index.js`)
* [ ] I added a sample use of the API (`example/App.js`)
