### PR TITLE
Added tvOS Compiler Flags

### DIFF
--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -15,7 +15,7 @@
 #import "RNDeviceInfo.h"
 #import "DeviceUID.h"
 
-#if !(TARGET_OS_TV)\
+#if !(TARGET_OS_TV)
 #import <WebKit/WebKit.h>
 #import <LocalAuthentication/LocalAuthentication.h>
 #endif

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -14,9 +14,9 @@
 #import <React/RCTUtils.h>
 #import "RNDeviceInfo.h"
 #import "DeviceUID.h"
-#import <WebKit/WebKit.h>
 
-#if !(TARGET_OS_TV)
+#if !(TARGET_OS_TV)\
+#import <WebKit/WebKit.h>
 #import <LocalAuthentication/LocalAuthentication.h>
 #endif
 
@@ -36,7 +36,9 @@ typedef NS_ENUM(NSInteger, DeviceType) {
 
 @implementation RNDeviceInfo
 {
+    #if !(TARGET_OS_TV)
     WKWebView *webView;
+    #endif
     bool hasListeners;
 }
 
@@ -526,7 +528,7 @@ RCT_EXPORT_METHOD(getUsedMemory:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
 
 RCT_EXPORT_METHOD(getUserAgent:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
 #if TARGET_OS_TV
-    reject(@"not available");
+    reject(@"not_available_error", @"not available on tvOS", nil);
 #else
     __weak RNDeviceInfo *weakSelf = self;
     dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
## Description

The latest version doesn't compile for the tvOS target because if the WebKit imports and usage. This PR adds some additional compiler flags so that it works again for tvOS.
 
## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| tvOS/iOS |    ✅   |

## Checklist

<!-- Check completed item: [X] -->

* [ x ] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`deviceinfo.d.ts`, `deviceinfo.js.flow`)
* [ ] I updated the dummy web/test polyfill (`default/index.js`)
* [ ] I added a sample use of the API (`example/App.js`)


