### PR TITLE
Expose getDeviceType as a static fn

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceConstants.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceConstants.java
@@ -1,0 +1,107 @@
+package com.learnium.RNDeviceInfo;
+
+import android.app.UiModeManager;
+import android.content.Context;
+import android.content.res.Configuration;
+import android.os.Build;
+import android.util.DisplayMetrics;
+import android.view.WindowManager;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+
+public class RNDeviceConstants {
+
+    protected static final String DEVICE_TYPE = "deviceType";
+    protected static final String IS_TABLET = "isTablet";
+
+    protected final Context context;
+    protected final Map<String, Object> constants = new HashMap<>();
+
+    public RNDeviceConstants(@Nonnull Context context) {
+        this.context = context;
+        DeviceType deviceType = getDeviceTypeImpl();
+        constants.put(DEVICE_TYPE, deviceType);
+        constants.put(IS_TABLET, deviceType == DeviceType.TABLET);
+    }
+
+    public DeviceType getDeviceType() {
+        return (DeviceType) constants.get(DEVICE_TYPE);
+    }
+
+    public boolean isTablet() {
+        return (boolean) constants.get(IS_TABLET);
+    }
+
+    protected DeviceType getDeviceTypeImpl() {
+        // Detect TVs via ui mode (Android TVs) or system features (Fire TV).
+        if (context.getPackageManager().hasSystemFeature("amazon.hardware.fire_tv")) {
+            return DeviceType.TV;
+        }
+
+        UiModeManager uiManager = (UiModeManager) context.getSystemService(Context.UI_MODE_SERVICE);
+        if (uiManager != null && uiManager.getCurrentModeType() == Configuration.UI_MODE_TYPE_TELEVISION) {
+            return DeviceType.TV;
+        }
+
+        DeviceType deviceTypeFromConfig = getDeviceTypeFromResourceConfiguration();
+
+        if (deviceTypeFromConfig != null && deviceTypeFromConfig != DeviceType.UNKNOWN) {
+            return deviceTypeFromConfig;
+        }
+
+        return  getDeviceTypeFromPhysicalSize();
+    }
+
+    // Use `smallestScreenWidthDp` to determine the screen size
+    // https://android-developers.googleblog.com/2011/07/new-tools-for-managing-screen-sizes.html
+    private DeviceType getDeviceTypeFromResourceConfiguration() {
+        int smallestScreenWidthDp = context.getResources().getConfiguration().smallestScreenWidthDp;
+
+        if (smallestScreenWidthDp == Configuration.SMALLEST_SCREEN_WIDTH_DP_UNDEFINED) {
+            return DeviceType.UNKNOWN;
+        }
+
+        return smallestScreenWidthDp >= 600 ? DeviceType.TABLET : DeviceType.HANDSET;
+    }
+
+    private DeviceType getDeviceTypeFromPhysicalSize() {
+        // Find the current window manager, if none is found we can't measure the device physical size.
+        WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+
+        if (windowManager == null) {
+            return DeviceType.UNKNOWN;
+        }
+
+        // Get display metrics to see if we can differentiate handsets and tablets.
+        // NOTE: for API level 16 the metrics will exclude window decor.
+        DisplayMetrics metrics = new DisplayMetrics();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            windowManager.getDefaultDisplay().getRealMetrics(metrics);
+        } else {
+            windowManager.getDefaultDisplay().getMetrics(metrics);
+        }
+
+        // Calculate physical size.
+        double widthInches = metrics.widthPixels / (double) metrics.xdpi;
+        double heightInches = metrics.heightPixels / (double) metrics.ydpi;
+        double diagonalSizeInches = Math.sqrt(Math.pow(widthInches, 2) + Math.pow(heightInches, 2));
+
+        if (diagonalSizeInches >= 3.0 && diagonalSizeInches <= 6.9) {
+            // Devices in a sane range for phones are considered to be Handsets.
+            return DeviceType.HANDSET;
+        } else if (diagonalSizeInches > 6.9 && diagonalSizeInches <= 18.0) {
+            // Devices larger than handset and in a sane range for tablets are tablets.
+            return DeviceType.TABLET;
+        } else {
+            // Otherwise, we don't know what device type we're on/
+            return DeviceType.UNKNOWN;
+        }
+    }
+
+    public Map<String, Object> getConstants() {
+        return constants;
+    }
+}

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceInfo.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceInfo.java
@@ -15,12 +15,22 @@ import javax.annotation.Nonnull;
 @SuppressWarnings("unused")
 public class RNDeviceInfo implements ReactPackage {
 
+  private RNDeviceConstants constants;
+
+  public RNDeviceInfo(RNDeviceConstants constants) {
+    this.constants = constants;
+  }
+
   @Override
   @Nonnull
   public List<NativeModule> createNativeModules(@Nonnull ReactApplicationContext reactContext) {
     List<NativeModule> modules = new ArrayList<>();
 
-    modules.add(new RNDeviceModule(reactContext));
+    if (constants == null) {
+      constants = new RNDeviceConstants(reactContext);
+    }
+
+    modules.add(new RNDeviceModule(reactContext, constants));
 
     return modules;
   }
@@ -35,5 +45,4 @@ public class RNDeviceInfo implements ReactPackage {
   public List<ViewManager> createViewManagers(@Nonnull ReactApplicationContext reactContext) {
     return Collections.emptyList();
   }
-
 }


### PR DESCRIPTION
## Description

This is useful for applications that need to query the device type on the native side before react native has started (e.g.: Application#onCreate)

## Checklist

<!-- Check completed item: [X] -->

* [ ] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`deviceinfo.d.ts`, `deviceinfo.js.flow`)
* [ ] I updated the dummy web/test polyfill (`default/index.js`)
* [ ] I added a sample use of the API (`example/App.js`)
