### PR TITLE
Check platform before querying readableVersion

### DIFF
--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -839,11 +839,19 @@ export function getVersionSync() {
 }
 
 export async function getReadableVersion() {
-  return (await RNDeviceInfo.getAppVersion()) + '.' + (await RNDeviceInfo.getBuildNumber());
+  if (OS === 'android' || OS === 'ios' || OS === 'windows') {
+    return (await RNDeviceInfo.getAppVersion()) + '.' + (await RNDeviceInfo.getBuildNumber());
+  } else {
+    return 'unknown';
+  }
 }
 
 export function getReadableVersionSync() {
-  return RNDeviceInfo.getAppVersionSync() + '.' + RNDeviceInfo.getBuildNumberSync();
+  if (OS === 'android' || OS === 'ios' || OS === 'windows') {
+    return RNDeviceInfo.getAppVersionSync() + '.' + RNDeviceInfo.getBuildNumberSync();
+  } else {
+    return 'unknown';
+  }    
 }
 
 let deviceName;


### PR DESCRIPTION
For web platforms, querying the readable version resulted in a crash. The extra platform check makes sure no undefined methods are called.

## Description

Fixed issue #796

Added platform check in getReadableVersion and getReadableVersionSync methods.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ✅     |
| Windows |    ✅     |
| Web | ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [X] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
