### PR TITLE
refactor: change `Unknown` to `unknown` for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # Release Notes
 
+## 4.0.1
+
+- BREAKING CHANGE: DeviceType: Renamed `Unknown` to `unknown` for consistency across the project
+- JavaScript replaced with TypeScript
+
 ## 3.1.4
 
 - fix: chain getReadableVersion APIs to JS vs native, protects web from native calls (Fixes #796)

--- a/README.md
+++ b/README.md
@@ -1269,7 +1269,7 @@ Returns the device's type as a string, which will be one of:
 * `Handset`
 * `Tablet`
 * `Tv`
-* `Unknown`
+* `unknown`
 
 #### Examples
 

--- a/android/src/main/java/com/learnium/RNDeviceInfo/DeviceType.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/DeviceType.java
@@ -4,7 +4,7 @@ public enum DeviceType {
     HANDSET ("Handset"),
     TABLET ("Tablet"),
     TV ("Tv"),
-    UNKNOWN ("Unknown");
+    UNKNOWN ("unknown");
 
     private final String value;
 

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -27,7 +27,7 @@ typedef NS_ENUM(NSInteger, DeviceType) {
     DeviceTypeUnknown
 };
 
-#define DeviceTypeValues [NSArray arrayWithObjects: @"Handset", @"Tablet", @"Tv", @"Unknown", nil]
+#define DeviceTypeValues [NSArray arrayWithObjects: @"Handset", @"Tablet", @"Tv", @"unknown", nil]
 
 #if !(TARGET_OS_TV)
 @import CoreTelephony;


### PR DESCRIPTION
For consistency, change the casing of `Unknown` to `unknown` like the rest of the library.

If we're happy with this, then we can add it to 4.0.x as a breaking change.