### PR TITLE
fix: android use googlePlayServicesIidVersion if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,20 @@
 
 # Release Notes
 
-## 4.0.1
+## 4.0.1-beta.2
 
-- BREAKING CHANGE: DeviceType: Renamed `Unknown` to `unknown` for consistency across the project
-- JavaScript replaced with TypeScript
+- fix: android use googlePlayServicesIidVersion if available (https://github.com/react-native-community/react-native-device-info/pull/804 / Fixes #802) @mikehardy
+
+## 4.0.1-beta.1
+
+- BREAKING CHANGE: DeviceType: Renamed `Unknown` to `unknown` for consistency across the project (@johan-dutoit)
+- fix: typescript conversion mopup (@johan-dutoit)
+
+## 4.0.0 (released / revoked on npm)
+
+This was almost working but had some issues so was revoked on npmjs.com
+
+- Conversion to typescript (https://github.com/react-native-community/react-native-device-info/pull/799) thanks @johan-dutoit!
 
 ## 3.1.4
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This module defaults to AndroidX you should configure your library versions simi
 ...
   ext {
     // dependency versions
-    googlePlayServicesVersion = "17.0.0" // default: "16.1.0" - pre-AndroidX, override for AndroidX
+    googlePlayServicesIidVersion = "17.0.0" // default: "17.0.0" - AndroidX, use "16.0.1" for pre-AndroidX
     compileSdkVersion = "28" // default: 28 (28 is required for AndroidX)
     targetSdkVersion = "28" // default: 28 (28 is required for AndroidX)
     supportLibVersion = '1.0.2' // Use '28.0.0' or don't specify for old libraries, '1.0.2' or similar for AndroidX

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,11 +1,15 @@
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+    // The Android Gradle plugin is only required when opening the android folder stand-alone.
+    // This avoids unnecessary downloads and potential conflicts when the library is included as a
+    // module dependency in an application project.
+    if (project == rootProject) {
+        repositories {
+            google()
+            jcenter()
+        }
+        dependencies {
+            classpath 'com.android.tools.build:gradle:3.5.0'
+        }
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,5 +45,6 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    implementation "com.google.android.gms:play-services-iid:${safeExtGet('googlePlayServicesVersion', '17.0.0')}"
+    def iidVersion = safeExtGet('googlePlayServicesIidVersion', safeExtGet('googlePlayServicesVersion', '17.0.0'))
+    implementation "com.google.android.gms:play-services-iid:$iidVersion"
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext {        googlePlayServicesVersion = "17.0.0"
+    ext {        googlePlayServicesIidVersion = "17.0.0"
         buildToolsVersion = "28.0.3"
         minSdkVersion = 16
         compileSdkVersion = 28

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -5167,7 +5167,7 @@ react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
 
 "react-native-device-info@github:react-native-community/react-native-device-info":
   version "4.0.0"
-  resolved "https://codeload.github.com/react-native-community/react-native-device-info/tar.gz/cfb779d60ef14c92f10d48af58584e041c86a068"
+  resolved "https://codeload.github.com/react-native-community/react-native-device-info/tar.gz/f449ae7e395a8071f4da982af2200eb846a01af8"
 
 react-native@0.60.5:
   version "0.60.5"

--- a/refresh-example-rn59.sh
+++ b/refresh-example-rn59.sh
@@ -31,7 +31,7 @@ yarn add github:react-native-community/react-native-device-info
 npx react-native link react-native-device-info
 
 # Patch the build.gradle directly to slice in our android play version
-sed -i -e 's/ext {$/ext {        googlePlayServicesVersion = "16.1.0"/' android/build.gradle
+sed -i -e 's/ext {$/ext {        googlePlayServicesIidVersion = "16.0.1"/' android/build.gradle
 sed -i -e 's/ext {$/ext {        minSdkVersion = 16/' android/build.gradle
 rm -f android/build.gradle??
 

--- a/refresh-example.sh
+++ b/refresh-example.sh
@@ -36,7 +36,7 @@ cd ios && pod install && cd ..
 
 # Patch the build.gradle directly to slice in our android play version
 # react-native 0.60 is AndroidX! Set up a bunch of AndroidX version
-sed -i -e 's/ext {$/ext {        googlePlayServicesVersion = "17.0.0"/' android/build.gradle
+sed -i -e 's/ext {$/ext {        googlePlayServicesIidVersion = "17.0.0"/' android/build.gradle
 sed -i -e 's/ext {$/ext {        minSdkVersion = 16/' android/build.gradle
 sed -i -e 's/ext {$/ext {        supportLibVersion = "1.0.2"/' android/build.gradle
 sed -i -e 's/ext {$/ext {        mediaCompatVersion = "1.0.1"/' android/build.gradle


### PR DESCRIPTION

#802 showed that the initial attempt at a backwards-compatible dependency on the specific iid library prompted by #746 vs the full play services library had an error in the pre-AndroidX versioning (and will fail in the future for AndroidX)

This adds a new gradle variable googlePlayServicesIidVersion which targets the specific dependency version, and we will only fall back to the existing googlePlayServicesVersion if the IidVersion is not available. So this should fix the issue and still be compatible with the installed base.

While I was in the area I altered our build.gradle style to conform with current react-native-community best practices from https://github.com/react-native-community/discussions-and-proposals/issues/151#issuecomment-532787908 and I committed a new version of example/yarn.lock for current development purposes

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [x] I mentioned this change in `CHANGELOG.md`
* [x] I added a sample use of the API (`example/App.js`)
