### PR TITLE
Restore pre-AndroidX compatibility out of the box

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -31,8 +31,6 @@ import android.util.DisplayMetrics;
 import android.hardware.Camera;
 import android.hardware.camera2.CameraManager;
 
-import androidx.annotation.Nullable;
-
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
@@ -55,6 +53,7 @@ import java.net.NetworkInterface;
 import java.math.BigInteger;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import static android.os.BatteryManager.BATTERY_STATUS_CHARGING;
 import static android.os.BatteryManager.BATTERY_STATUS_FULL;


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Use `javax.annotation.Nullable` instead of `androidx.annotation.Nullable`. This makes it unnecessary to use `jetifier -r` just for this one line.

https://github.com/react-native-community/react-native-device-info/commit/50793700a0a1868684ca7215a4da4ec3034ce0fc#commitcomment-35340391

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |
| Windows |    ✅❌     |

## Checklist

<!-- Check completed item: [X] -->

* [ ] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I updated the dummy web/test polyfill (`default/index.js`)
* [ ] I added a sample use of the API (`example/App.js`)
