### PR TITLE
Implement constants for windows, and a github action to verify windows build

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,23 @@
+name: PR
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  Windows:
+    name: Windows
+    runs-on: windows-2016
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - run: yarn install --frozen-lockfile
+
+      - run: yarn build
+
+      - name: Setup MSBuild.exe
+        uses: warrenbuckley/Setup-MSBuild@v1
+
+      - name: Build RNDeviceInfo.sln
+        run: msbuild windows\RNDeviceInfo\RNDeviceInfo.sln /nologo /nr:false /p:PreferredToolArchitecture=x64 /p:platform="x86" /p:configuration="Debug"

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ examplern59
 
 # generated files by bob
 lib/
+
+# Visual Studio build artifacts
+windows/RNDeviceInfo/.vs/*
+windows/RNDeviceInfo/obj/*

--- a/windows/RNDeviceInfo/RNDeviceInfoModule.cs
+++ b/windows/RNDeviceInfo/RNDeviceInfoModule.cs
@@ -9,6 +9,7 @@ using Windows.Security.Credentials.UI;
 using Windows.Networking;
 using Windows.Networking.Connectivity;
 using System.Linq;
+using Newtonsoft.Json.Linq;
 
 namespace RNDeviceInfo
 {
@@ -24,6 +25,26 @@ namespace RNDeviceInfo
             get
             {
                 return "RNDeviceInfo";
+            }
+        }
+
+        public override JObject ModuleConstants
+        {
+            get
+            {
+                return new JObject
+                {
+                    { "uniqueId", getUniqueIdSync() },
+                    { "deviceId", getDeviceIdSync() },
+                    { "bundleId", getBundleIdSync() },
+                    { "systemVersion", getSystemVersionSync() },
+                    { "appVersion", getAppVersionSync() },
+                    { "buildNumber", getBuildNumberSync() },
+                    { "isTablet", isTabletSync() },
+                    { "appName", getAppNameSync() },
+                    { "brand", getBrandSync() },
+                    { "model", getModelSync() },
+                };
             }
         }
 


### PR DESCRIPTION
## Description

Fixed issue #817 for windows

I also added a github action definition to at least run a build of the windows code for future validation.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ❌     |
| Windows |    ✅     |

## Checklist

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I updated the dummy web/test polyfill (`default/index.js`)
* [ ] I added a sample use of the API (`example/App.js`)
