### PR TITLE
Fix wrong example code of hasNotch() in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1260,9 +1260,8 @@ Tells if the device has a notch.
 #### Examples
 
 ```js
-DeviceInfo.hasNotch().then(hasNotch => {
+let hasNotch = DeviceInfo.hasNotch();
   // true
-});
 ```
 
 ---


### PR DESCRIPTION
## Description

Fixed issue #843 

Though return type of hasNotch in API table was right, example code was still Promise-based code.