### PR TITLE
Fix README saying a promise is returned when it's actually a string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Every API returns a Promise but also has a corresponding API with 'Sync' on the 
 | [getCarrier()](#getcarrier)                                       | `Promise<string>`   |  ✅  |   ✅    |   ❌    |
 | [getCodename()](#getcodename)                                     | `Promise<string>`   |  ❌  |   ✅    |   ❌    |
 | [getDevice()](#getdevice)                                         | `Promise<string>`   |  ❌  |   ✅    |   ❌    |
-| [getDeviceId()](#getdeviceid)                                     | `Promise<string>`   |  ✅  |   ✅    |   ✅    |
+| [getDeviceId()](#getdeviceid)                                     | `string`            |  ✅  |   ✅    |   ✅    |
 | [getDeviceType()](#getDeviceType)                                 | `string`            |  ✅  |   ✅    |   ❌    |
 | [getDisplay()](#getdisplay)                                       | `Promise<string>`   |  ❌  |   ✅    |   ❌    |
 | [getDeviceName()](#getdevicename)                                 | `Promise<string>`   |  ✅  |   ✅    |   ✅    |


### PR DESCRIPTION
Fixed issue in README where it is said that `getDeviceId()` returns a `Promise<string>` when it actually returns a `string`.