### PR TITLE
fix(ios): app display name being null

### DIFF
--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -139,7 +139,9 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
 }
 
 - (NSString *) getAppName {
-    return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+    NSString *displayName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+    NSString *bundleName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
+    return displayName ? displayName : bundleName;
 }
 
 - (NSString *) getBundleId {


### PR DESCRIPTION
## Description

Fixed issue #846 


---
`getAppName` will return `CFBundleName` for those cases where `CFBundleDisplayName` is null 
