### PR TITLE
Using latest iid library from firebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1261,7 +1261,7 @@ Tells if the device has a notch.
 
 ```js
 let hasNotch = DeviceInfo.hasNotch();
-// true
+  // true
 ```
 
 ---
@@ -1406,11 +1406,11 @@ Fired when the battery level changes; sent no more frequently than once per minu
 #### Examples
 
 ```js
-import { useBatteryLevel } from 'react-native-device-info';
+import { useBatteryLevel } from 'react-native-device-info'
 
 const batteryLevel = useBatteryLevel(); // 0.759999
 
-<Text>{batteryLevel}</Text>;
+<Text>{ batteryLevel }</Text>
 ```
 
 ```js
@@ -1436,11 +1436,11 @@ Fired when the battery drops is considered low
 #### Examples
 
 ```js
-import { useBatteryLevelIsLow } from 'react-native-device-info';
+import { useBatteryLevelIsLow } from 'react-native-device-info'
 
 const batteryLevelIsLow = useBatteryLevelIsLow(); // 0.19
 
-<Text>{batteryLevelIsLow}</Text>;
+<Text>{ batteryLevelIsLow }</Text>
 ```
 
 ```js
@@ -1461,11 +1461,11 @@ Fired when the battery state changes, for example when the device enters chargin
 #### Examples
 
 ```js
-import { usePowerState } from 'react-native-device-info';
+import { usePowerState } from 'react-native-device-info'
 
 const powerState = usePowerState(); // 'charging'
 
-<Text>{powerState}</Text>;
+<Text>{ powerState }</Text>
 ```
 
 ```js

--- a/README.md
+++ b/README.md
@@ -56,7 +56,17 @@ This module defaults to AndroidX you should configure your library versions simi
 ...
   ext {
     // dependency versions
-    iidVersion = "19.0.1" // default: "19.0.1" - AndroidX, use "16.0.1" for pre-AndroidX
+
+    We have 3 options for deviceId:
+    //Option 1 (latest):
+    firebaseIidVersion = "19.0.1" // default: "19.0.1"
+    //Option 2 (legacy GooglePlay dependency but using AndroidX):
+    googlePlayServicesIidVersion = "17.0.0" // default: "17.0.0" - AndroidX
+    //Option 3 (legacy GooglePlay dependency before AndroidX):
+    googlePlayServicesIidVersion = "16.0.1" 
+    
+    
+    //include as needed:
     compileSdkVersion = "28" // default: 28 (28 is required for AndroidX)
     targetSdkVersion = "28" // default: 28 (28 is required for AndroidX)
     supportLibVersion = '1.0.2' // Use '28.0.0' or don't specify for old libraries, '1.0.2' or similar for AndroidX

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This module defaults to AndroidX you should configure your library versions simi
 ...
   ext {
     // dependency versions
-    googlePlayServicesIidVersion = "17.0.0" // default: "17.0.0" - AndroidX, use "16.0.1" for pre-AndroidX
+    iidVersion = "19.0.1" // default: "19.0.1" - AndroidX, use "16.0.1" for pre-AndroidX
     compileSdkVersion = "28" // default: 28 (28 is required for AndroidX)
     targetSdkVersion = "28" // default: 28 (28 is required for AndroidX)
     supportLibVersion = '1.0.2' // Use '28.0.0' or don't specify for old libraries, '1.0.2' or similar for AndroidX
@@ -1261,7 +1261,7 @@ Tells if the device has a notch.
 
 ```js
 let hasNotch = DeviceInfo.hasNotch();
-  // true
+// true
 ```
 
 ---
@@ -1406,11 +1406,11 @@ Fired when the battery level changes; sent no more frequently than once per minu
 #### Examples
 
 ```js
-import { useBatteryLevel } from 'react-native-device-info'
+import { useBatteryLevel } from 'react-native-device-info';
 
 const batteryLevel = useBatteryLevel(); // 0.759999
 
-<Text>{ batteryLevel }</Text>
+<Text>{batteryLevel}</Text>;
 ```
 
 ```js
@@ -1436,11 +1436,11 @@ Fired when the battery drops is considered low
 #### Examples
 
 ```js
-import { useBatteryLevelIsLow } from 'react-native-device-info'
+import { useBatteryLevelIsLow } from 'react-native-device-info';
 
 const batteryLevelIsLow = useBatteryLevelIsLow(); // 0.19
 
-<Text>{ batteryLevelIsLow }</Text>
+<Text>{batteryLevelIsLow}</Text>;
 ```
 
 ```js
@@ -1461,11 +1461,11 @@ Fired when the battery state changes, for example when the device enters chargin
 #### Examples
 
 ```js
-import { usePowerState } from 'react-native-device-info'
+import { usePowerState } from 'react-native-device-info';
 
 const powerState = usePowerState(); // 'charging'
 
-<Text>{ powerState }</Text>
+<Text>{powerState}</Text>;
 ```
 
 ```js

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,6 +45,6 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    def iidVersion = safeExtGet('googlePlayServicesIidVersion', safeExtGet('googlePlayServicesVersion', '17.0.0'))
-    implementation "com.google.android.gms:play-services-iid:$iidVersion"
+    def iidVersion = safeExtGet('iidVersion', safeExtGet('iidVersion', '19.0.1'))
+    implementation "com.google.firebase:firebase-iid:$iidVersion"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,6 +45,11 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    def iidVersion = safeExtGet('iidVersion', safeExtGet('iidVersion', '19.0.1'))
-    implementation "com.google.firebase:firebase-iid:$iidVersion"
+    def firebaseIidVersion = safeExtGet('firebaseIidVersion', null))
+    if(firebaseIidVersion){
+        implementation "com.google.firebase:firebase-iid:$firebaseIidVersion"
+    }else{
+        def iidVersion = safeExtGet('googlePlayServicesIidVersion', safeExtGet('googlePlayServicesVersion', '17.0.0'))
+        implementation "com.google.android.gms:play-services-iid:$iidVersion"
+    }
 }

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -726,6 +726,8 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     try {
       if (Class.forName("com.google.firebase.iid.FirebaseInstanceId") != null) {
         return com.google.firebase.iid.FirebaseInstanceId.getInstance().getId();
+      }else if (Class.forName("com.google.android.gms.iid.InstanceID") != null) {
+        return com.google.android.gms.iid.InstanceID.getInstance(getReactApplicationContext()).getId();
       }
     } catch (ClassNotFoundException e) {
       System.err.println("N/A: Add com.google.firebase:firebase-iid to your project.");

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -724,11 +724,11 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   @SuppressWarnings({"ConstantConditions", "deprecation"})
   public String getInstanceIdSync() {
     try {
-      if (Class.forName("com.google.android.gms.iid.InstanceID") != null) {
-        return com.google.android.gms.iid.InstanceID.getInstance(getReactApplicationContext()).getId();
+      if (Class.forName("com.google.firebase.iid.FirebaseInstanceId") != null) {
+        return com.google.firebase.iid.FirebaseInstanceId.getInstance().getId();
       }
     } catch (ClassNotFoundException e) {
-      System.err.println("N/A: Add com.google.android.gms:play-services-gcm to your project.");
+      System.err.println("N/A: Add com.google.firebase:firebase-iid to your project.");
     }
     return "unknown";
   }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext {        googlePlayServicesIidVersion = "17.0.0"
+    ext {        iidVersion = "19.0.1"
         buildToolsVersion = "28.0.3"
         minSdkVersion = 16
         compileSdkVersion = 28

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext {        iidVersion = "19.0.1"
+    ext {        firebaseIidVersion = "19.0.1"
         buildToolsVersion = "28.0.3"
         minSdkVersion = 16
         compileSdkVersion = 28

--- a/refresh-example-rn59.sh
+++ b/refresh-example-rn59.sh
@@ -34,7 +34,8 @@ npx react-native link react-native-device-info
 
 
 # Patch the build.gradle directly to slice in our android play version
-sed -i -e 's/ext {$/ext {        googlePlayServicesIidVersion = "16.0.1"/' android/build.gradle
+sed -i -e 's/ext {$/ext {        iidVersion = "16.0.1"/' android/build.gradle
+sed -i -e 's/com.google.firebase:firebase-iid/com.google.android.gms:play-services-iid' android/build.gradle
 sed -i -e 's/ext {$/ext {        minSdkVersion = 16/' android/build.gradle
 rm -f android/build.gradle??
 

--- a/refresh-example-rn59.sh
+++ b/refresh-example-rn59.sh
@@ -34,8 +34,7 @@ npx react-native link react-native-device-info
 
 
 # Patch the build.gradle directly to slice in our android play version
-sed -i -e 's/ext {$/ext {        iidVersion = "16.0.1"/' android/build.gradle
-sed -i -e 's/com.google.firebase:firebase-iid/com.google.android.gms:play-services-iid' android/build.gradle
+sed -i -e 's/ext {$/ext {        firebaseIidVersion = "19.0.1"/' android/build.gradle
 sed -i -e 's/ext {$/ext {        minSdkVersion = 16/' android/build.gradle
 rm -f android/build.gradle??
 

--- a/refresh-example.sh
+++ b/refresh-example.sh
@@ -36,7 +36,7 @@ cd ios && pod install && cd ..
 
 # Patch the build.gradle directly to slice in our android play version
 # react-native 0.60 is AndroidX! Set up a bunch of AndroidX version
-sed -i -e 's/ext {$/ext {        iidVersion = "19.0.1"/' android/build.gradle
+sed -i -e 's/ext {$/ext {        firebaseIidVersion = "19.0.1"/' android/build.gradle
 sed -i -e 's/ext {$/ext {        minSdkVersion = 16/' android/build.gradle
 sed -i -e 's/ext {$/ext {        supportLibVersion = "1.0.2"/' android/build.gradle
 sed -i -e 's/ext {$/ext {        mediaCompatVersion = "1.0.1"/' android/build.gradle

--- a/refresh-example.sh
+++ b/refresh-example.sh
@@ -36,7 +36,7 @@ cd ios && pod install && cd ..
 
 # Patch the build.gradle directly to slice in our android play version
 # react-native 0.60 is AndroidX! Set up a bunch of AndroidX version
-sed -i -e 's/ext {$/ext {        googlePlayServicesIidVersion = "17.0.0"/' android/build.gradle
+sed -i -e 's/ext {$/ext {        iidVersion = "17.0.0"/' android/build.gradle
 sed -i -e 's/ext {$/ext {        minSdkVersion = 16/' android/build.gradle
 sed -i -e 's/ext {$/ext {        supportLibVersion = "1.0.2"/' android/build.gradle
 sed -i -e 's/ext {$/ext {        mediaCompatVersion = "1.0.1"/' android/build.gradle

--- a/refresh-example.sh
+++ b/refresh-example.sh
@@ -36,7 +36,7 @@ cd ios && pod install && cd ..
 
 # Patch the build.gradle directly to slice in our android play version
 # react-native 0.60 is AndroidX! Set up a bunch of AndroidX version
-sed -i -e 's/ext {$/ext {        iidVersion = "17.0.0"/' android/build.gradle
+sed -i -e 's/ext {$/ext {        iidVersion = "19.0.1"/' android/build.gradle
 sed -i -e 's/ext {$/ext {        minSdkVersion = 16/' android/build.gradle
 sed -i -e 's/ext {$/ext {        supportLibVersion = "1.0.2"/' android/build.gradle
 sed -i -e 's/ext {$/ext {        mediaCompatVersion = "1.0.1"/' android/build.gradle


### PR DESCRIPTION
## Description
iid library: com.google.android.gms:play-services-iid has been deprecated as per: https://developers.google.com/android/reference/com/google/android/gms/iid/package-summary
It has been replaced with firebase
Fixed issue #<issue-number>

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [X ] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I updated the dummy web/test polyfill (`default/index.js`)
* [ ] I added a sample use of the API (`example/App.js`)
