### PR TITLE
Adding useLandscape()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1502,6 +1502,24 @@ deviceInfoEmitter.addListener('RNDeviceInfo_powerStateDidChange', { batteryState
 
 ---
 
+### useLandscape
+
+Tells if the device is currently in landscape mode.
+
+_This hook listens to dimension change events, determines if the window is in landscape, then updates the result accordingly._
+
+#### Example
+
+```jsx
+import { useLandscape } from 'react-native-device-info';
+
+const isLandscape = useLandscape(); // true or false
+
+<Text>{isLandscape}</Text>;
+```
+
+---
+
 ### useFirstInstallTime
 
 Gets the time at which the app was first installed, in milliseconds.

--- a/example/App.js
+++ b/example/App.js
@@ -16,6 +16,7 @@ import {
   useBatteryLevel,
   useBatteryLevelIsLow,
   usePowerState,
+  useLandscape,
   useFirstInstallTime,
   useDeviceName,
 } from 'react-native-device-info';
@@ -24,12 +25,14 @@ const FunctionalComponent = () => {
   const batteryLevel = useBatteryLevel();
   const batteryLevelIsLow = useBatteryLevelIsLow();
   const powerState = usePowerState();
+  const isLandscape = useLandscape();
   const firstInstallTime = useFirstInstallTime();
   const deviceName = useDeviceName();
   const deviceJSON = {
     batteryLevel,
     batteryLevelIsLow,
     powerState,
+    isLandscape,
     firstInstallTime,
     deviceName,
   };

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -141,6 +141,7 @@ declare module.exports: {
   useBatteryLevel: () => number | null,
   useBatteryLevelIsLow: () => number | null,
   usePowerState: () => PowerState | {},
+  useLandscape: () => boolean,
   useFirstInstallTime: () => AsyncHookResult<number>,
   useDeviceName: () => AsyncHookResult<string>
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Platform, Dimensions, NativeEventEmitter, NativeModules } from 'react-native';
+import { Platform, Dimensions, NativeEventEmitter, NativeModules, ScaledSize } from 'react-native';
 import RNDeviceInfo from './internal/nativeInterface';
 import devicesWithNotch from './internal/devicesWithNotch';
 import { DeviceType, PowerState, AsyncHookResult } from './internal/types';
@@ -1246,6 +1246,31 @@ export function usePowerState(): PowerState | {} {
   return powerState;
 }
 
+/**
+ * hook that listens to Dimension change event to determine if window is in landscape after said change
+ */
+export function useLandscape(): boolean {
+  // initial state setup
+  const [result, setResult] = useState<boolean>(isLandscapeSync());
+
+  // eqv to `componentWillMount` when 'deps' param is an empty array
+  useEffect(() => {
+    const type = 'change';
+    const handler = ({ window }: { window: ScaledSize }) => {
+      setResult(window.width >= window.height);
+    };
+
+    Dimensions.addEventListener(type, handler);
+
+    // componentWillUnmount
+    return () => {
+      Dimensions.removeEventListener(type, handler);
+    };
+  }, []);
+
+  return result;
+}
+
 export function useFirstInstallTime(): AsyncHookResult<number> {
   return useOnMount(getFirstInstallTime, -1);
 }
@@ -1373,6 +1398,7 @@ export default {
   useBatteryLevel,
   useBatteryLevelIsLow,
   usePowerState,
+  useLandscape,
   useFirstInstallTime,
   useDeviceName,
 };


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

<!-- OR, if you're implementing a new feature: -->

### Added `useLandscape()`

This hook listens to `Dimensions`' change events, then updates state on change.
This allows for effects to be made when the device enters or leaves landscape mode. (show drawer menu button in header when not in landscape, show / open drawer menu when in landscape, etc...)

I decided to not have the return type as `AsyncHookResult<boolean>` since there won't be a point where the the result isn't known, so a `loading` prop would be unnecessary.
 
With that being said, if we want to have `AsyncHookResult<boolean>` as the return type, I can change it to be so.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [X] I have tested this on a device/simulator for each compatible OS
* [X] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [X] I added a sample use of the API (`example/App.js`)
