### PR TITLE
add useIsEmulator hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1548,6 +1548,21 @@ const { loading, result } = useHasSystemFeature('amazon.hardware.fire_tv'); // {
 <Text>{loading ? 'loading...' : result}</Text>;
 ```
 
+### useIsEmulator
+
+Get whether the application is running in an emulator.
+
+#### Example
+
+```jsx
+import { useIsEmulator } from 'react-native-device-info';
+
+const { loading, result } = useDeviceName(); // { loading: true, result: false }
+
+<Text>{loading ? 'loading...' : result}</Text>;
+```
+
+---
 =======
 ## Native interoperatibily
 

--- a/README.md
+++ b/README.md
@@ -1548,6 +1548,8 @@ const { loading, result } = useHasSystemFeature('amazon.hardware.fire_tv'); // {
 <Text>{loading ? 'loading...' : result}</Text>;
 ```
 
+---
+
 ### useIsEmulator
 
 Get whether the application is running in an emulator.
@@ -1562,7 +1564,6 @@ const { loading, result } = useDeviceName(); // { loading: true, result: false }
 <Text>{loading ? 'loading...' : result}</Text>;
 ```
 
----
 =======
 ## Native interoperatibily
 

--- a/example/App.js
+++ b/example/App.js
@@ -7,7 +7,7 @@
  * @lint-ignore-every XPLATJSCOPYRIGHT1
  */
 
-import React, {Component, Fragment} from 'react';
+import React, {Component} from 'react';
 import {ScrollView, StyleSheet, Text, SafeAreaView} from 'react-native';
 import DeviceInfo from 'react-native-device-info';
 import {
@@ -19,6 +19,7 @@ import {
   useFirstInstallTime,
   useDeviceName,
   useHasSystemFeature,
+  useIsEmulator,
 } from 'react-native-device-info';
 
 const FunctionalComponent = () => {
@@ -28,6 +29,7 @@ const FunctionalComponent = () => {
   const firstInstallTime = useFirstInstallTime();
   const deviceName = useDeviceName();
   const hasSystemFeature = useHasSystemFeature('amazon.hardware.fire_tv');
+  const isEmulator = useIsEmulator();
   const deviceJSON = {
     batteryLevel,
     batteryLevelIsLow,
@@ -35,6 +37,7 @@ const FunctionalComponent = () => {
     firstInstallTime,
     deviceName,
     hasSystemFeature,
+    isEmulator,
   };
 
   return (

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -144,4 +144,5 @@ declare module.exports: {
   useFirstInstallTime: () => AsyncHookResult<number>,
   useDeviceName: () => AsyncHookResult<string>,
   useHasSystemFeature: (feature: string) => AsyncHookResult<boolean>
+  useIsEmulator: () => AsyncHookResult<boolean>
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1259,6 +1259,10 @@ export function useHasSystemFeature(feature: string): AsyncHookResult<boolean> {
   return useOnMount(asyncGetter, false);
 }
 
+export function useIsEmulator(): AsyncHookResult<boolean> {
+  return useOnMount(isEmulator, false);
+}
+
 export default {
   getUniqueId,
   getInstanceId,
@@ -1381,4 +1385,5 @@ export default {
   useFirstInstallTime,
   useDeviceName,
   useHasSystemFeature,
+  useIsEmulator,
 };


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Related issue #776 

https://github.com/react-native-community/react-native-device-info/issues/776#issuecomment-545780483

Added `useIsEmulator()` that allows to get whether the application is running in an emulator.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

* [ ] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [x] I added a sample use of the API (`example/App.js`)
