### PR TITLE
Fix flow syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "url": "https://github.com/react-native-community/react-native-device-info"
   },
   "scripts": {
-    "analyze": "npx tsc --noEmit",
+    "analyze": "yarn ts-check && yarn flow-check",
+    "flow-check": "npx flow-bin check-contents < src/index.js.flow",
+    "ts-check": "npx tsc --noEmit",
     "clean": "cd example && npx react-native-clean-project --keep-node-modules --remove-iOS-build --remove-iOS-pods --remove-android-build --keep-brew --keep-pods && \\rm -fr ios/Pods",
     "dev-sync": "yarn build && cp -r *podspec lib windows web android ios src example/node_modules/react-native-device-info/",
     "lint": "npx eslint ./ --ignore-pattern example --ignore-pattern node_modules --fix --quiet",

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -15,7 +15,7 @@ export type LocationProviderInfo = {
   [key: string]: boolean,
 };
 
-export type AsyncHookResult<T> {
+export type AsyncHookResult<T> = {
   loading: boolean,
   result: T | -1 | false | 'unknown',
 }
@@ -143,6 +143,6 @@ declare module.exports: {
   usePowerState: () => PowerState | {},
   useFirstInstallTime: () => AsyncHookResult<number>,
   useDeviceName: () => AsyncHookResult<string>,
-  useHasSystemFeature: (feature: string) => AsyncHookResult<boolean>
+  useHasSystemFeature: (feature: string) => AsyncHookResult<boolean>,
   useIsEmulator: () => AsyncHookResult<boolean>
 };


### PR DESCRIPTION
The flow syntax was invalid so type checking was failing:

```
Error ------------------------------------------- node_modules/react-native-device-info/lib/commonjs/index.js.flow:18:32

Unexpected token {

   18| export type AsyncHookResult<T> {

                                      ^

Error --------------------------------------------- node_modules/react-native-device-info/lib/module/index.js.flow:18:32

Unexpected token {

   18| export type AsyncHookResult<T> {

                                      ^

Error ---------------------------------------------------- node_modules/react-native-device-info/src/index.js.flow:18:32

Unexpected token {

   18| export type AsyncHookResult<T> {

                                      ^
```