### PR TITLE
Added support to get Android’s current "Locating method"

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -125,6 +125,7 @@ export default class App extends Component {
     deviceJSON.getSystemAvailableFeatures = DeviceInfo.getSystemAvailableFeaturesSync();
     deviceJSON.powerState = DeviceInfo.getPowerStateSync();
     deviceJSON.isLocationEnabled = DeviceInfo.isLocationEnabledSync();
+    deviceJSON.androidLocatingMethod = DeviceInfo.getAndroidLocatingMethod();
     deviceJSON.headphones = DeviceInfo.isHeadphonesConnectedSync();
     deviceJSON.getAvailableLocationProviders = DeviceInfo.getAvailableLocationProvidersSync();
     deviceJSON.bootloader = DeviceInfo.getBootloaderSync();
@@ -187,6 +188,7 @@ export default class App extends Component {
       deviceJSON.getSystemAvailableFeatures = await DeviceInfo.getSystemAvailableFeatures();
       deviceJSON.powerState = await DeviceInfo.getPowerState();
       deviceJSON.isLocationEnabled = await DeviceInfo.isLocationEnabled();
+      deviceJSON.androidLocatingMethod = await DeviceInfo.getAndroidLocatingMethod();
       deviceJSON.headphones = await DeviceInfo.isHeadphonesConnected();
       deviceJSON.getAvailableLocationProviders = await DeviceInfo.getAvailableLocationProviders();
       deviceJSON.bootloader = await DeviceInfo.getBootloader();

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,14 @@ export async function getAndroidId() {
   return androidId;
 }
 
+export function getAndroidLocatingMethod() {
+  if (Platform.OS === 'android') {
+    return RNDeviceInfo.getAndroidLocatingMethod();
+  } else {
+    return null;
+  }
+}
+
 export function getAndroidIdSync() {
   if (!androidId) {
     if (Platform.OS === 'android') {

--- a/src/internal/privateTypes.ts
+++ b/src/internal/privateTypes.ts
@@ -124,6 +124,7 @@ interface ExposedNativeMethods {
   isHeadphonesConnectedSync: () => boolean;
   isLocationEnabled: () => Promise<boolean>;
   isLocationEnabledSync: () => boolean;
+  getAndroidLocatingMethod: () => Promise<string>;
   isPinOrFingerprintSet: () => Promise<boolean>;
   isPinOrFingerprintSetSync: () => boolean;
 }


### PR DESCRIPTION
## Description

Added `getAndroidLocatingMethod()` that allows to get device current "Locating method" (HighAccuracy / BatterySaving / SensorsOnly / Off)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     | relevant only to Android
| Android |    ✅     |
| Windows |   ❌     | 

## Checklist

<!-- Check completed item: [v] -->

* [v] I have tested this on a device/simulator for each compatible OS
* [v ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md` // was not sure if I the one who should do it
* [v] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [v] I added a sample use of the API (`example/App.js`)
