### PR TITLE
feat(getDeviceToken) add getDeviceToken to get token using DeviceCheck API (ios only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Release Notes
 
+- feat: Added getDeviceToken() using DeviceCheck API on iOS 11.0+
+
 ## 5.3.1
 - types: fix Flow types (thanks @grit96!)
 

--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ Every API returns a Promise but also has a corresponding API with 'Sync' on the 
 | [getDeviceType()](#getDeviceType)                                 | `string`            |  ✅  |   ✅    |   ❌    | ❌ |
 | [getDisplay()](#getdisplay)                                       | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌ |
 | [getDeviceName()](#getdevicename)                                 | `Promise<string>`   |  ✅  |   ✅    |   ✅    | ❌ |
+| [getDeviceToken()](#getdevicetoken)                               | `Promise<string>`   |  ✅  |   ❌    |   ❌    | ❌ |
 | [getFirstInstallTime()](#getfirstinstalltime)                     | `Promise<number>`   |  ❌  |   ✅    |   ✅    | ❌ |
 | [getFingerprint()](#getfingerprint)                               | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌ |
 | [getFontScale()](#getfontscale)                                   | `Promise<number>`   |  ✅  |   ✅    |   ❌    | ❌ |
@@ -628,6 +629,21 @@ DeviceInfo.getDeviceName().then(deviceName => {
 ```
 
 This used to require the android.permission.BLUETOOTH but the new implementation in v3 does not need it. You may remove that from your AndroidManifest.xml if you had it for this API.
+
+---
+
+### getDeviceToken()
+
+Gets the device token (see [DeviceCheck](https://developer.apple.com/documentation/devicecheck)). Only available for iOS 11.0+.
+
+#### Examples
+
+```js
+DeviceInfo.getDeviceToken().then(deviceToken => {
+  // iOS: "a2Jqsd0kanz..."
+});
+```
+
 
 ---
 

--- a/example/App.js
+++ b/example/App.js
@@ -205,6 +205,7 @@ export default class App extends Component {
       deviceJSON.incremental = await DeviceInfo.getIncremental();
       deviceJSON.supported32BitAbis = await DeviceInfo.supported32BitAbis();
       deviceJSON.supported64BitAbis = await DeviceInfo.supported64BitAbis();
+      deviceJSON.deviceToken = await DeviceInfo.getDeviceToken();
     } catch (e) {
       console.log('Trouble getting device info ', e);
     }

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -14,6 +14,7 @@
 #import <React/RCTUtils.h>
 #import "RNDeviceInfo.h"
 #import "DeviceUID.h"
+#import <DeviceCheck/DeviceCheck.h>
 
 #if !(TARGET_OS_TV)
 #import <WebKit/WebKit.h>
@@ -372,6 +373,27 @@ RCT_EXPORT_METHOD(isEmulator:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromis
         return YES;
     } else {
         return NO;
+    }
+}
+
+RCT_EXPORT_METHOD(getDeviceToken:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    if (@available(iOS 11.0, *)) {
+        DCDevice *device = DCDevice.currentDevice;
+        if([device isSupported])
+        {
+            [DCDevice.currentDevice generateTokenWithCompletionHandler:^(NSData * _Nullable token, NSError * _Nullable error) {
+                if(error) {
+                    reject(@"ERROR GENERATING TOKEN", error.localizedDescription, error);
+                }
+                resolve([token base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithLineFeed]);
+            }];
+        }
+        else {
+            reject(@"NOT SUPPORTED", @"Device check is not supported by this device", nil);
+        }
+    }
+    else {
+        reject(@"NOT AVAILABLE",  @"Device check is only available for iOS > 11", nil);
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1201,6 +1201,13 @@ export function getAvailableLocationProvidersSync() {
   return {};
 }
 
+export async function getDeviceToken() {
+  if (Platform.OS === 'ios') {
+    return RNDeviceInfo.getDeviceToken();
+  }
+  return 'unknown';
+}
+
 const deviceInfoEmitter = new NativeEventEmitter(NativeModules.RNDeviceInfo);
 export function useBatteryLevel(): number | null {
   const [batteryLevel, setBatteryLevel] = useState<number | null>(null);
@@ -1322,6 +1329,7 @@ const deviceInfoModule: DeviceInfoModule = {
   getDeviceName,
   getDeviceNameSync,
   getDeviceSync,
+  getDeviceToken,
   getDeviceType,
   getDisplay,
   getDisplaySync,

--- a/src/internal/privateTypes.ts
+++ b/src/internal/privateTypes.ts
@@ -58,6 +58,7 @@ interface ExposedNativeMethods {
   getDeviceName: () => Promise<string>;
   getDeviceNameSync: () => string;
   getDeviceSync: () => string;
+  getDeviceToken: () => Promise<string>;
   getDisplay: () => Promise<string>;
   getDisplaySync: () => string;
   getFingerprint: () => Promise<string>;


### PR DESCRIPTION
## Description

Implements `getDeviceToken` using [DeviceCheck API](https://developer.apple.com/documentation/devicecheck)
(Closes #658 )

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |      ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [x] I mentioned this change in `CHANGELOG.md`
* [x] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [x] I added a sample use of the API (`example/App.js`)
