### PR TITLE
Fix upgrade links in README.md TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Device Information for [React Native](https://github.com/facebook/react-native).
 
 ## TOC
 
-- [v2 to v3 Upgrade](#v2tov3upgrade)
-- [v3 to v4 Upgrade](#v3tov4upgrade)
+- [v2 to v3 Upgrade](#v2-to-v3-upgrade)
+- [v3 to v4 Upgrade](#v3-to-v4-upgrade)
 - [Installation](#installation)
 - [Linking](#linking-for-react-native--059-only-react-native--060-skip-this-as-auto-linking-should-work)
 - [Usage](#usage)


### PR DESCRIPTION
## Description

Just a simple documentation fix - currently upgrade links in TOC do not scroll view to desired part of readme. This PR fixes that issue.

## Compatibility

n/a

## Checklist

n/a