### PR TITLE
Utilize install referrer API over BroadcastReceiver.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Release Notes
 
+- fix: used new play install referrer api over soon-to-be-deprecated install_referrer intent
+
 ## 5.4.0
 
 - feat + fix: tabbed example, improved types, efficient Platform usage (thanks @zoontek!)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    implementation "com.android.installreferrer:installreferrer:1.1"
+    implementation "com.android.installreferrer:installreferrer:${safeExtGet('installReferrerVersion', '1.1')}"
     def firebaseIidVersion = safeExtGet('firebaseIidVersion', null)
     if(firebaseIidVersion){
         implementation "com.google.firebase:firebase-iid:$firebaseIidVersion"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,6 +48,7 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
+    implementation "com.android.installreferrer:installreferrer:1.1"
     def firebaseIidVersion = safeExtGet('firebaseIidVersion', null)
     if(firebaseIidVersion){
         implementation "com.google.firebase:firebase-iid:$firebaseIidVersion"

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -69,6 +69,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   private final DeviceTypeResolver deviceTypeResolver;
   private final DeviceIdResolver deviceIdResolver;
   private BroadcastReceiver receiver;
+  private RNInstallReferrerClient installReferrerClient;
 
   private double mLastBatteryLevel = -1;
   private String sLastBatteryState = "";
@@ -81,6 +82,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     super(reactContext);
     this.deviceTypeResolver = new DeviceTypeResolver(reactContext);
     this.deviceIdResolver = new DeviceIdResolver(reactContext);
+    this.installReferrerClient = new RNInstallReferrerClient(reactContext.getBaseContext());
   }
 
   @Override

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceReceiver.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceReceiver.java
@@ -8,12 +8,6 @@ import android.content.SharedPreferences;
 public class RNDeviceReceiver extends BroadcastReceiver {
   @Override
   public void onReceive(Context context, Intent intent) {
-    String action = intent.getAction();
-    if ("com.android.vending.INSTALL_REFERRER".equals(action)) {
-      SharedPreferences sharedPref = context.getSharedPreferences("react-native-device-info", Context.MODE_PRIVATE);
-      SharedPreferences.Editor editor = sharedPref.edit();
-      editor.putString("installReferrer", intent.getStringExtra("referrer"));
-      editor.apply();
-    }
+    
   }
 }

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceReceiver.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceReceiver.java
@@ -8,6 +8,12 @@ import android.content.SharedPreferences;
 public class RNDeviceReceiver extends BroadcastReceiver {
   @Override
   public void onReceive(Context context, Intent intent) {
-    
+    String action = intent.getAction();
+    if ("com.android.vending.INSTALL_REFERRER".equals(action)) {
+      SharedPreferences sharedPref = context.getSharedPreferences("react-native-device-info", Context.MODE_PRIVATE);
+      SharedPreferences.Editor editor = sharedPref.edit();
+      editor.putString("installReferrer", intent.getStringExtra("referrer"));
+      editor.apply();
+    }
   }
 }

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNInstallReferrerClient.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNInstallReferrerClient.java
@@ -1,0 +1,53 @@
+package com.learnium.RNDeviceInfo;
+
+import android.content.SharedPreferences;
+import android.content.Context;
+import android.os.RemoteException;
+
+import com.android.installreferrer.api.InstallReferrerClient;
+import com.android.installreferrer.api.InstallReferrerStateListener;
+import com.android.installreferrer.api.ReferrerDetails;
+
+import static com.android.installreferrer.api.InstallReferrerClient.InstallReferrerResponse;
+
+public class RNInstallReferrerClient implements InstallReferrerStateListener {
+
+  private SharedPreferences sharedPreferences;
+  private InstallReferrerClient referrerClient;
+
+  RNInstallReferrerClient(Context context) {
+    referrerClient = InstallReferrerClient.newBuilder(context).build();
+    sharedPreferences = context.getSharedPreferences("react-native-device-info", Context.MODE_PRIVATE);
+  }
+
+  private String getInstallReferrer() {
+    try {
+      return referrerClient
+        .getInstallReferrer()
+        .getInstallReferrer();
+    } catch (RemoteException e) {
+      e.printStackTrace();
+      return null;
+    }
+  }
+
+  @Override
+  public void onInstallReferrerSetupFinished(int responseCode) {
+    switch (responseCode) {
+      case InstallReferrerResponse.OK:
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor.putString("installReferrer", getInstallReferrer());
+        editor.apply();
+        break;
+      case InstallReferrerResponse.FEATURE_NOT_SUPPORTED:
+        break;
+      case InstallReferrerResponse.SERVICE_UNAVAILABLE:
+        break;
+    }
+  }
+
+  @Override
+  public void onInstallReferrerServiceDisconnected() {
+
+  }
+}

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNInstallReferrerClient.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNInstallReferrerClient.java
@@ -16,8 +16,9 @@ public class RNInstallReferrerClient implements InstallReferrerStateListener {
   private InstallReferrerClient referrerClient;
 
   RNInstallReferrerClient(Context context) {
-    referrerClient = InstallReferrerClient.newBuilder(context).build();
     sharedPreferences = context.getSharedPreferences("react-native-device-info", Context.MODE_PRIVATE);
+    referrerClient = InstallReferrerClient.newBuilder(context).build();
+    referrerClient.startConnection(this);
   }
 
   private String getInstallReferrer() {


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Google Play is deprecating the install_referrer intent,
they recommend switching to the new [Play Install Referrer library](https://developer.android.com/google/play/installreferrer/library.html)

I've not made any contributions to open source repos yet, and
I'm not super aware of the behavior of the install_referrer intent nor the new library, so
comments/notes/tips/hints are all gold 👍 

Fixed issue #909 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [X] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [X] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
