### PR TITLE
feat: getBottomNavigationBarHeight()

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,8 @@ The device's navigation bar height.
 
 ```js
 let navBarHeight = DeviceInfo.getBottomNavigationBarHeight();
-// 10
+// iOS: 10 or 0 (depends on the model)
+// Android: x (depends on the navigation mode. Ex: gesture, 2-button or 3-button)
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ DeviceInfo.getBootloader().then(bootloader => {
 
 ### getBottomNavigationBarHeight()
 
-The system bootloader version number.
+The device's navigation bar height.
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ Every API returns a Promise but also has a corresponding API with 'Sync' on the 
 | [getBuildId()](#getbuildid)                                       | `Promise<string>`   |  ✅  |   ✅    |   ❌    | ❌ |
 | [getBatteryLevel()](#getbatterylevel)                             | `Promise<number>`   |  ✅  |   ✅    |   ✅    | ✅ |
 | [getBootloader()](#getbootloader)                                 | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌ |
+| [getBottomNavigationBarHeight()](#getBottomNavigationBarHeight)   | `number`            |  ✅  |   ✅    |   ❌    | ❌ |
 | [getBrand()](#getbrand)                                           | `string`            |  ✅  |   ✅    |   ✅    | ❌ |
 | [getBuildNumber()](#getbuildnumber)                               | `string`            |  ✅  |   ✅    |   ✅    | ❌ |
 | [getBundleId()](#getbundleid)                                     | `string`            |  ✅  |   ✅    |   ✅    | ❌ |
@@ -473,6 +474,19 @@ The system bootloader version number.
 DeviceInfo.getBootloader().then(bootloader => {
   // "mw8998-002.0069.00"
 });
+```
+
+---
+
+### getBottomNavigationBarHeight()
+
+The system bootloader version number.
+
+#### Examples
+
+```js
+let navBarHeight = DeviceInfo.getBottomNavigationBarHeight();
+// 10
 ```
 
 ---

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -786,7 +786,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     Resources resources = getReactApplicationContext().getResources();
     int resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android");
       if (resourceId > 0) {
-        return resources.getDimensionPixelSize(resourceId);
+        return (int) (resources.getDimension(resourceId) / resources.getDisplayMetrics().density);
       }
     return 0;
   }

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -171,7 +171,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     constants.put("brand", Build.BRAND);
     constants.put("model", Build.MODEL);
     constants.put("deviceType", deviceTypeResolver.getDeviceType().getValue());
-    constants.put("bottomNavigationHeight", getBottomNavigationHeight());
+    constants.put("bottomNavigationBarHeight", getBottomNavigationBarHeight());
 
     return constants;
   }
@@ -782,7 +782,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void getSupported64BitAbis(Promise p) { p.resolve(getSupported64BitAbisSync()); }
 
-  private int getBottomNavigationHeight(){
+  private int getBottomNavigationBarHeight(){
     Resources resources = getReactApplicationContext().getResources();
     int resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android");
       if (resourceId > 0) {
@@ -792,7 +792,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   }
 
 
-    private WritableMap getPowerStateFromIntent (Intent intent) {
+  private WritableMap getPowerStateFromIntent (Intent intent) {
     if(intent == null) {
       return null;
     }

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -11,6 +11,7 @@ import android.content.IntentFilter;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.FeatureInfo;
+import android.content.res.Resources;
 import android.location.LocationManager;
 import android.media.AudioManager;
 import android.net.wifi.WifiManager;
@@ -170,6 +171,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     constants.put("brand", Build.BRAND);
     constants.put("model", Build.MODEL);
     constants.put("deviceType", deviceTypeResolver.getDeviceType().getValue());
+    constants.put("bottomNavigationHeight", getBottomNavigationHeight());
 
     return constants;
   }
@@ -780,8 +782,17 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void getSupported64BitAbis(Promise p) { p.resolve(getSupported64BitAbisSync()); }
 
+  private int getBottomNavigationHeight(){
+    Resources resources = getReactApplicationContext().getResources();
+    int resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android");
+      if (resourceId > 0) {
+        return resources.getDimensionPixelSize(resourceId);
+      }
+    return 0;
+  }
 
-  private WritableMap getPowerStateFromIntent (Intent intent) {
+
+    private WritableMap getPowerStateFromIntent (Intent intent) {
     if(intent == null) {
       return null;
     }

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -69,6 +69,7 @@ RCT_EXPORT_MODULE();
          @"brand": @"Apple",
          @"model": [self getModel],
          @"deviceType": [self getDeviceTypeName],
+         @"bottomNavigationBarHeight": [self getBottomNavigationBarHeight],
      };
 }
 
@@ -486,6 +487,15 @@ RCT_EXPORT_METHOD(getFreeDiskStorage:(RCTPromiseResolveBlock)resolve rejecter:(R
 
 - (NSString *) getDeviceTypeName {
     return [DeviceTypeValues objectAtIndex: [self getDeviceType]];
+}
+
+- (int) getBottomNavigationBarHeight {
+    NSString* name = [self getDeviceName];
+    if ([name containsString:@"iPhone X"] || [name containsString:@"iPhone 1"]) {
+        return 16; // Nav bar
+    } else {
+        return 0; // No nav bar
+    }
 }
 
 - (NSArray *) getSupportedAbis {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1301,6 +1301,14 @@ export function useIsEmulator(): AsyncHookResult<boolean> {
   return useOnMount(isEmulator, false);
 }
 
+export function getBottomNavigationBarHeight(): number {
+  if (Platform.OS === 'android' || Platform.OS === 'ios') {
+    return RNDeviceInfo.bottomNavigationBarHeight;
+  } else {
+    return -1;
+  }
+}
+
 const deviceInfoModule: DeviceInfoModule = {
   getAndroidId,
   getAndroidIdSync,
@@ -1315,6 +1323,7 @@ const deviceInfoModule: DeviceInfoModule = {
   getBatteryLevelSync,
   getBootloader,
   getBootloaderSync,
+  getBottomNavigationBarHeight,
   getBrand,
   getBuildId,
   getBuildIdSync,

--- a/src/internal/privateTypes.ts
+++ b/src/internal/privateTypes.ts
@@ -20,6 +20,7 @@ interface NativeConstants {
   systemName: string;
   systemVersion: string;
   uniqueId: string;
+  bottomNavigationBarHeight: number;
 }
 
 interface HiddenNativeMethods {
@@ -139,6 +140,7 @@ export interface DeviceInfoModule extends ExposedNativeMethods {
   getBrand: () => string;
   getBuildNumber: () => string;
   getBundleId: () => string;
+  getBottomNavigationBarHeight: () => number;
   getDeviceId: () => string;
   getDeviceType: () => string;
   getManufacturer: () => Promise<string>;


### PR DESCRIPTION
## Description
Added `getBottomNavigationBarHeight()` that allows ...

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [x] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
