### PR TITLE
feat: add getInstallerPackageName for android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Release Notes
 
+## 5.5.0
+
+feat: add getInstallerPackageName for android (#912) (thanks @codecog!)
+
 ## 5.4.4
 
 - feat: add Huawei P Smart devices to notch list (#945) (thanks @sanborN!)

--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ Every API returns a Promise but also has a corresponding API with 'Sync' on the 
 | [getHost()](#gethost)                                             | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌ |
 | [getIpAddress()](#getipaddress)                                   | `Promise<string>`   |  ✅  |   ✅    |   ✅    | ❌ |
 | [getIncremental()](#getincremental)                               | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌ |
+| [getInstallerPackageName()](#getinstallerpackagename)             | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌ |
 | [getInstallReferrer()](#getinstallreferrer)                       | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ✅ |
 | [getInstanceId()](#getinstanceid)                                 | `Promise<string>`   |  ❌  |   ✅    |   ❌    | ❌ |
 | [getLastUpdateTime()](#getlastupdatetime)                         | `Promise<number>`   |  ❌  |   ✅    |   ❌    | ❌ |
@@ -781,6 +782,23 @@ The internal value used by the underlying source control to represent this build
 ```js
 DeviceInfo.getIncremental().then(incremental => {
   // "4820017"
+});
+```
+
+---
+
+### getInstallerPackageName()
+
+The internal value used by the underlying source control to represent this build.
+
+#### Examples
+
+```js
+DeviceInfo.getInstallerPackageName().then(installerPackageName => {
+  // Play Store: "com.android.vending"
+  // Amazon: "com.amazon.venezia"
+  // Samsung App Store: "com.sec.android.app.samsungapps"
+  // Developer, iOS: "unknown"
 });
 ```
 

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -504,6 +504,20 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     return getReactApplicationContext().getPackageManager().getPackageInfo(getReactApplicationContext().getPackageName(), 0);
   }
 
+  private String getInstallerPackageNameSync() {
+    String packageName = getReactApplicationContext().getPackageName();
+    String installerPackageName = getReactApplicationContext().getPackageManager().getInstallerPackageName(packageName);
+
+    if (installerPackageName == null) {
+      return "unknown";
+    }
+
+    return installerPackageName;
+  }
+
+  @ReactMethod
+  public void getInstallerPackageName(Promise p) { p.resolve(getInstallerPackageNameSync()); }
+
   @ReactMethod(isBlockingSynchronousMethod = true)
   public double getFirstInstallTimeSync() {
     try {

--- a/example/App.js
+++ b/example/App.js
@@ -97,6 +97,7 @@ export default class App extends Component {
     deviceJSON.usedMemory = DeviceInfo.getUsedMemorySync();
     deviceJSON.instanceId = DeviceInfo.getInstanceIdSync();
     deviceJSON.installReferrer = DeviceInfo.getInstallReferrerSync();
+    deviceJSON.installerPackageName = DeviceInfo.getInstallerPackageNameSync();
     deviceJSON.isEmulator = DeviceInfo.isEmulatorSync();
     deviceJSON.fontScale = DeviceInfo.getFontScaleSync();
     deviceJSON.hasNotch = DeviceInfo.hasNotch();
@@ -159,6 +160,7 @@ export default class App extends Component {
       deviceJSON.userAgent = await DeviceInfo.getUserAgent();
       deviceJSON.instanceId = await DeviceInfo.getInstanceId();
       deviceJSON.installReferrer = await DeviceInfo.getInstallReferrer();
+      deviceJSON.installerPackageName = await DeviceInfo.getInstallerPackageName();
       deviceJSON.isEmulator = await DeviceInfo.isEmulator();
       deviceJSON.fontScale = await DeviceInfo.getFontScale();
       deviceJSON.hasNotch = await DeviceInfo.hasNotch();

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -66,6 +66,8 @@ declare module.exports: {
   getHostSync: () => string,
   getIncremental: () => Promise<string>,
   getIncrementalSync: () => string,
+  getInstallerPackageName: () => Promise<string>,
+  getInstallerPackageNameSync: () => string,
   getInstallReferrer: () => Promise<string>,
   getInstallReferrerSync: () => string,
   getInstanceId: () => Promise<string>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -282,6 +282,31 @@ export function getBundleId() {
   return bundleId;
 }
 
+let installerPackageName: string;
+export async function getInstallerPackageName() {
+  if (!installerPackageName) {
+    if (Platform.OS === 'android') {
+      installerPackageName = await RNDeviceInfo.getInstallerPackageName();
+    } else {
+      installerPackageName = 'unknown';
+    }
+  }
+
+  return installerPackageName;
+}
+
+export function getInstallerPackageNameSync() {
+  if (!installerPackageName) {
+    if (Platform.OS === 'android') {
+      installerPackageName = RNDeviceInfo.getInstallerPackageNameSync();
+    } else {
+      installerPackageName = 'unknown';
+    }
+  }
+
+  return installerPackageName;
+}
+
 let appName: string;
 export function getApplicationName() {
   if (!appName) {
@@ -1347,6 +1372,8 @@ const deviceInfoModule: DeviceInfoModule = {
   getHostSync,
   getIncremental,
   getIncrementalSync,
+  getInstallerPackageName,
+  getInstallerPackageNameSync,
   getInstallReferrer,
   getInstallReferrerSync,
   getInstanceId,

--- a/src/internal/privateTypes.ts
+++ b/src/internal/privateTypes.ts
@@ -75,6 +75,8 @@ interface ExposedNativeMethods {
   getHostSync: () => string;
   getIncremental: () => Promise<string>;
   getIncrementalSync: () => string;
+  getInstallerPackageName: () => Promise<string>;
+  getInstallerPackageNameSync: () => string;
   getInstallReferrer: () => Promise<string>;
   getInstallReferrerSync: () => string;
   getInstanceId: () => Promise<string>;


### PR DESCRIPTION
Signed-off-by: Josh Kelly <josh@codecog.dev>

<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description
<!-- OR, if you're implementing a new feature: -->

Adds request from Issue #912

`getInstallerPackageName()` provides the ability to fetch the location where an apk was installed from. Return values have been added to the docs.

## Compatibility

| OS            | Implemented |
| --------- | :---------: |
| iOS           |    ❌     |
| Android   |    ✅     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [X] I have tested this on a device/simulator for each compatible OS
* [X] I added the documentation in `README.md`
* [X] I mentioned this change in `CHANGELOG.md`
* [X] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [X] I added a sample use of the API (`example/App.js`)
