### PR TITLE
install_referrer api over soon to be deprecated

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,6 +48,7 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
+    implementation "com.android.installreferrer:installreferrer:${safeExtGet('installReferrerVersion', '1.1.1')}"
     def firebaseIidVersion = safeExtGet('firebaseIidVersion', null)
     if(firebaseIidVersion){
         implementation "com.google.firebase:firebase-iid:$firebaseIidVersion"

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -69,6 +69,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   private final DeviceTypeResolver deviceTypeResolver;
   private final DeviceIdResolver deviceIdResolver;
   private BroadcastReceiver receiver;
+  private RNInstallReferrerClient installReferrerClient;
 
   private double mLastBatteryLevel = -1;
   private String sLastBatteryState = "";
@@ -81,6 +82,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     super(reactContext);
     this.deviceTypeResolver = new DeviceTypeResolver(reactContext);
     this.deviceIdResolver = new DeviceIdResolver(reactContext);
+    this.installReferrerClient = new RNInstallReferrerClient(reactContext.getBaseContext());
   }
 
   @Override

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNInstallReferrerClient.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNInstallReferrerClient.java
@@ -3,58 +3,71 @@ package com.learnium.RNDeviceInfo;
 import android.content.SharedPreferences;
 import android.content.Context;
 import android.os.RemoteException;
+import android.util.Log;
 
 import com.android.installreferrer.api.InstallReferrerClient;
 import com.android.installreferrer.api.InstallReferrerStateListener;
 import com.android.installreferrer.api.ReferrerDetails;
 
-import static com.android.installreferrer.api.InstallReferrerClient.InstallReferrerResponse;
-
-public class RNInstallReferrerClient implements InstallReferrerStateListener {
+public class RNInstallReferrerClient {
 
   private SharedPreferences sharedPreferences;
-  private InstallReferrerClient referrerClient;
+  private InstallReferrerClient mReferrerClient;
 
   RNInstallReferrerClient(Context context) {
     sharedPreferences = context.getSharedPreferences("react-native-device-info", Context.MODE_PRIVATE);
-    referrerClient = InstallReferrerClient.newBuilder(context).build();
-    referrerClient.startConnection(this);
+    mReferrerClient = InstallReferrerClient.newBuilder(context).build();
+    mReferrerClient.startConnection(installReferrerStateListener);
   }
 
   private String getInstallReferrer() {
     try {
-      return referrerClient
-        .getInstallReferrer()
-        .getInstallReferrer();
+      return mReferrerClient
+              .getInstallReferrer()
+              .getInstallReferrer();
     } catch (RemoteException e) {
       e.printStackTrace();
       return null;
     }
   }
 
-  referrerClient.startConnection(new InstallReferrerStateListener() {
-    @Override
-    public void onInstallReferrerSetupFinished(int responseCode) {
-      switch (responseCode) {
-        case InstallReferrerResponse.OK:
-          // Connection established
-          SharedPreferences.Editor editor = sharedPreferences.edit();
-          editor.putString("installReferrer", getInstallReferrer());
-          editor.apply();
-          break;
-        case InstallReferrerResponse.FEATURE_NOT_SUPPORTED:
-          // API not available on the current Play Store app
-          break;
-        case InstallReferrerResponse.SERVICE_UNAVAILABLE:
-          // Connection could not be established
-          break;
-      }
-    }
+  private InstallReferrerStateListener installReferrerStateListener =
+    new InstallReferrerStateListener() {
+      @Override public void onInstallReferrerSetupFinished(int responseCode) {
+        switch (responseCode) {
+          case InstallReferrerClient.InstallReferrerResponse.OK:
+            // Connection established
+            try {
+              if (BuildConfig.DEBUG) Log.d("InstallReferrerState", "OK");
+              ReferrerDetails response = mReferrerClient.getInstallReferrer();
+              response.getInstallReferrer();
+              response.getReferrerClickTimestampSeconds();
+              response.getInstallBeginTimestampSeconds();
 
-    @Override
-    public void onInstallReferrerServiceDisconnected() {
-      // Try to restart the connection on the next request to
-      // Google Play by calling the startConnection() method.
-    }
-  });
+              SharedPreferences.Editor editor = sharedPreferences.edit();
+              editor.putString("installReferrer", getInstallReferrer());
+              editor.apply();
+
+              mReferrerClient.endConnection();
+            } catch (RemoteException e) {
+              e.printStackTrace();
+            }
+            break;
+          case InstallReferrerClient.InstallReferrerResponse.FEATURE_NOT_SUPPORTED:
+            if (BuildConfig.DEBUG) Log.d("InstallReferrerState", "FEATURE_NOT_SUPPORTED");
+            // API not available on the current Play Store app
+            break;
+          case InstallReferrerClient.InstallReferrerResponse.SERVICE_UNAVAILABLE:
+            if (BuildConfig.DEBUG) Log.d("InstallReferrerState", "SERVICE_UNAVAILABLE");
+            // Connection could not be established
+            break;
+        }
+      }
+
+      @Override public void onInstallReferrerServiceDisconnected() {
+        // Try to restart the connection on the next request to
+        // Google Play by calling the startConnection() method.
+        mReferrerClient.startConnection(installReferrerStateListener);
+      }
+    };
 }

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNInstallReferrerClient.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNInstallReferrerClient.java
@@ -1,0 +1,60 @@
+package com.learnium.RNDeviceInfo;
+
+import android.content.SharedPreferences;
+import android.content.Context;
+import android.os.RemoteException;
+
+import com.android.installreferrer.api.InstallReferrerClient;
+import com.android.installreferrer.api.InstallReferrerStateListener;
+import com.android.installreferrer.api.ReferrerDetails;
+
+import static com.android.installreferrer.api.InstallReferrerClient.InstallReferrerResponse;
+
+public class RNInstallReferrerClient implements InstallReferrerStateListener {
+
+  private SharedPreferences sharedPreferences;
+  private InstallReferrerClient referrerClient;
+
+  RNInstallReferrerClient(Context context) {
+    sharedPreferences = context.getSharedPreferences("react-native-device-info", Context.MODE_PRIVATE);
+    referrerClient = InstallReferrerClient.newBuilder(context).build();
+    referrerClient.startConnection(this);
+  }
+
+  private String getInstallReferrer() {
+    try {
+      return referrerClient
+        .getInstallReferrer()
+        .getInstallReferrer();
+    } catch (RemoteException e) {
+      e.printStackTrace();
+      return null;
+    }
+  }
+
+  referrerClient.startConnection(new InstallReferrerStateListener() {
+    @Override
+    public void onInstallReferrerSetupFinished(int responseCode) {
+      switch (responseCode) {
+        case InstallReferrerResponse.OK:
+          // Connection established
+          SharedPreferences.Editor editor = sharedPreferences.edit();
+          editor.putString("installReferrer", getInstallReferrer());
+          editor.apply();
+          break;
+        case InstallReferrerResponse.FEATURE_NOT_SUPPORTED:
+          // API not available on the current Play Store app
+          break;
+        case InstallReferrerResponse.SERVICE_UNAVAILABLE:
+          // Connection could not be established
+          break;
+      }
+    }
+
+    @Override
+    public void onInstallReferrerServiceDisconnected() {
+      // Try to restart the connection on the next request to
+      // Google Play by calling the startConnection() method.
+    }
+  });
+}


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Use new `InstallReferrerClient` before to be deprecated by Google Play Store.

Fixed issue <https://github.com/react-native-community/react-native-device-info/issues/909>

<!-- OR, if you're implementing a new feature: -->

Documentation:

- https://developer.android.com/google/play/installreferrer/library.html#java
- https://mvnrepository.com/artifact/com.android.installreferrer/installreferrer

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌  |
| Android |     ✅   |
| Windows |    ❌   |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
