### PR TITLE
fix: add mac catalyst compatibility to getCarrier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Release Notes
 
+## 5.5.4
+
+- fix: add mac catalyst compatibility to getCarrier (#973) (thanks @robertying!)
+
 ## 5.5.3
 
 - fix: add Redmi Note 9 to hasNotch list (#959) (thanks @euharrison!)

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -288,7 +288,7 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
 }
 
 - (NSString *) getCarrier {
-#if (TARGET_OS_TV)
+#if (TARGET_OS_TV || TARGET_OS_MACCATALYST)
     return @"unknown";
 #else
     CTTelephonyNetworkInfo *netinfo = [[CTTelephonyNetworkInfo alloc] init];


### PR DESCRIPTION
## Description

device-info is working great for mac catalyst target, except for `getCarrier`.

I just added a macro check to fix this.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |

## Checklist

Hmm. This is a pretty subtle change and I don't know if I need to modify CHANGELOG and README, etc.
