### PR TITLE
Fix issue where getModel on iOS would never return the generic names, only "unknown" if the real device name wasn't found.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - fix: memoization of static boolean return values (@jmheik)
 - fix: add mac catalyst compatibility to getCarrier (#973) (thanks @robertying!)
 - fix: add wider exception handling in install referrer (thanks @jmunozDevsu!)
+- fix: getModel on iOS now returns generic device type (e.g. "iPhone") if the specific model is unrecognized (@TheAlmightyBob)
 
 ## 5.5.3
 

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -273,13 +273,13 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
     }
 
     // If we don't have the real device name, try a generic
-    if ([deviceName hasPrefix:@"iPod"]) {
+    if ([deviceId hasPrefix:@"iPod"]) {
         return @"iPod Touch";
-    } else if ([deviceName hasPrefix:@"iPad"]) {
+    } else if ([deviceId hasPrefix:@"iPad"]) {
         return @"iPad";
-    } else if ([deviceName hasPrefix:@"iPhone"]) {
+    } else if ([deviceId hasPrefix:@"iPhone"]) {
         return @"iPhone";
-    } else if ([deviceName hasPrefix:@"AppleTV"]) {
+    } else if ([deviceId hasPrefix:@"AppleTV"]) {
         return @"Apple TV";
     }
 


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

This appears to have been a simple typo in the iOS implementation of `getModel`. It was checking if `deviceName` was `nil`, and it if _was_, then it was continuing to parse `deviceName`. This was clearly not the intent.

This is such a small fix that I wasn't sure it was worth creating an issue for or adding to `CHANGELOG.md`, but happy to do so if others disagree.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |

(this fix doesn't affect Android/Windows...)

## Checklist

<!-- Check completed item: [X] -->

* [X] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
