### PR TITLE
Update RNInstallReferrerClient.java

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNInstallReferrerClient.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNInstallReferrerClient.java
@@ -45,7 +45,7 @@ public class RNInstallReferrerClient {
           case InstallReferrerClient.InstallReferrerResponse.OK:
             // Connection established
             try {
-              if (BuildConfig.DEBUG) Log.d("InstallReferrerState", "OK");
+              //if (BuildConfig.DEBUG) Log.d("InstallReferrerState", "OK");
               ReferrerDetails response = mReferrerClient.getInstallReferrer();
               response.getInstallReferrer();
               response.getReferrerClickTimestampSeconds();
@@ -62,7 +62,7 @@ public class RNInstallReferrerClient {
             }
             break;
           case InstallReferrerClient.InstallReferrerResponse.FEATURE_NOT_SUPPORTED:
-            if (BuildConfig.DEBUG) Log.d("InstallReferrerState", "FEATURE_NOT_SUPPORTED");
+            //if (BuildConfig.DEBUG) Log.d("InstallReferrerState", "FEATURE_NOT_SUPPORTED");
             // API not available on the current Play Store app
             break;
           case InstallReferrerClient.InstallReferrerResponse.SERVICE_UNAVAILABLE:
@@ -75,7 +75,7 @@ public class RNInstallReferrerClient {
       @Override public void onInstallReferrerServiceDisconnected() {
         // Documentation indicates the InstallReferrer connection will be maintained
         // So there is really nothing to do here
-        if (BuildConfig.DEBUG) Log.d("RNInstallReferrerClient", "InstallReferrerService disconnected");
+        //if (BuildConfig.DEBUG) Log.d("RNInstallReferrerClient", "InstallReferrerService disconnected");
       }
     };
 }

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNInstallReferrerClient.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNInstallReferrerClient.java
@@ -45,7 +45,8 @@ public class RNInstallReferrerClient {
           case InstallReferrerClient.InstallReferrerResponse.OK:
             // Connection established
             try {
-              //if (BuildConfig.DEBUG) Log.d("InstallReferrerState", "OK");
+              //if (BuildConfig.DEBUG) 
+              Log.d("InstallReferrerState", "OK");
               ReferrerDetails response = mReferrerClient.getInstallReferrer();
               response.getInstallReferrer();
               response.getReferrerClickTimestampSeconds();
@@ -62,11 +63,13 @@ public class RNInstallReferrerClient {
             }
             break;
           case InstallReferrerClient.InstallReferrerResponse.FEATURE_NOT_SUPPORTED:
-            //if (BuildConfig.DEBUG) Log.d("InstallReferrerState", "FEATURE_NOT_SUPPORTED");
+            //if (BuildConfig.DEBUG) 
+            Log.d("InstallReferrerState", "FEATURE_NOT_SUPPORTED");
             // API not available on the current Play Store app
             break;
           case InstallReferrerClient.InstallReferrerResponse.SERVICE_UNAVAILABLE:
-            if (BuildConfig.DEBUG) Log.d("InstallReferrerState", "SERVICE_UNAVAILABLE");
+            //if (BuildConfig.DEBUG) 
+            Log.d("InstallReferrerState", "SERVICE_UNAVAILABLE");
             // Connection could not be established
             break;
         }
@@ -75,7 +78,8 @@ public class RNInstallReferrerClient {
       @Override public void onInstallReferrerServiceDisconnected() {
         // Documentation indicates the InstallReferrer connection will be maintained
         // So there is really nothing to do here
-        //if (BuildConfig.DEBUG) Log.d("RNInstallReferrerClient", "InstallReferrerService disconnected");
+        //if (BuildConfig.DEBUG) 
+        Log.d("RNInstallReferrerClient", "InstallReferrerService disconnected");
       }
     };
 }


### PR DESCRIPTION
When we use react-native-device-info in Electrode native project, there is an error during container compiling:
 
:heavy_multiplication_x: An error occurred: Command failed: ./gradlew lib:uploadArchives
:heavy_multiplication_x: /private/var/folders/kc/hj8kf3gd5w55_39001pwxy9m0000gp/T/tmp-494366bW875QsqbOB/lib/src/main/java/com/learnium/RNDeviceInfo/RNInstallReferrerClient.java:78: error: cannot find symbol
:heavy_multiplication_x:     if (BuildConfig.DEBUG) Log.d(“RNInstallReferrerClient”, “InstallReferrerService disconnected”);


The reason is BuildConfig was generated in the package: com.walmartlabs.ern.container

For this, could you please comment out those BuildConfig.DEBUG lines,  if you need to, probably better to specify the class package.

Thanks

<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes #<issue-number>

<!-- OR, if you're implementing a new feature: -->

Added `yourNewMethodName()` that allows ...

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |
| Windows |    ✅❌     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
