### PR TITLE
Add AVAudioSessionPortBluetoothHFP to AVAudioSession check

### DIFF
--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -665,6 +665,9 @@ RCT_EXPORT_METHOD(isLocationEnabled:(RCTPromiseResolveBlock)resolve rejecter:(RC
         if ([[desc portType] isEqualToString:AVAudioSessionPortBluetoothA2DP]) {
             return YES;
         }
+	if ([[desc portType] isEqualToString:AVAudioSessionPortBluetoothHFP]) {
+            return YES;
+        }
     }
     return NO;
 }

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -665,7 +665,7 @@ RCT_EXPORT_METHOD(isLocationEnabled:(RCTPromiseResolveBlock)resolve rejecter:(RC
         if ([[desc portType] isEqualToString:AVAudioSessionPortBluetoothA2DP]) {
             return YES;
         }
-	if ([[desc portType] isEqualToString:AVAudioSessionPortBluetoothHFP]) {
+        if ([[desc portType] isEqualToString:AVAudioSessionPortBluetoothHFP]) {
             return YES;
         }
     }


### PR DESCRIPTION
<!--
Adding AVAudioSessionPortBluetoothHFP as a list of acceptable bluetooth headphone types. There are other types that could be acceptable as well, you can see the full list provided here https://developer.apple.com/documentation/avfoundation/avaudiosessionport?language=objc

Its worth noting that when a VOIP call is active the apple airpods return as `AVAudioSessionPortBluetoothHFP` while otherwise would be returned as `AVAudioSessionPortBluetoothA2DP`
-->

## Description

Fixes #1009 for iOS


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅❌     |
| Windows |    ✅❌     |
