### PR TITLE
Fix: TypeError: Cannot assign to read only property 'exports' of object '#<Object>'

### DIFF
--- a/src/web/index.js
+++ b/src/web/index.js
@@ -6,6 +6,18 @@ let batteryCharging = false,
   batteryLevel = -1,
   powerState = {};
 
+const _readPowerState = (battery) => {
+  const { level, charging, chargingtime, dischargingtime } = battery;
+
+  return {
+    batteryLevel: level,
+    lowPowerMode: false,
+    batteryState: level === 1 ? 'full' : charging ? 'charging' : 'unplugged',
+    chargingtime,
+    dischargingtime,
+  };
+}
+
 export const getMaxMemorySync = () => {
   if (window.performance && window.performance.memory) {
     return window.performance.memory.jsHeapSizeLimit;
@@ -53,7 +65,7 @@ const init = async () => {
       const { charging } = battery;
 
       batteryCharging = charging;
-      powerState = getPowerStateSync(battery);
+      powerState = _readPowerState(battery);
 
       deviceInfoEmitter.emit('RNDeviceInfo_powerStateDidChange', powerState);
     });
@@ -62,7 +74,7 @@ const init = async () => {
       const { level } = battery;
 
       batteryLevel = level;
-      powerState = getPowerStateSync(battery);
+      powerState = _readPowerState(battery);
 
       deviceInfoEmitter.emit('RNDeviceInfo_batteryLevelDidChange', level);
       if (level < 0.2) {
@@ -205,19 +217,12 @@ export const getTotalMemory = async () => {
 export const getPowerState = async () => {
   if (navigator.getBattery) {
     const battery = await navigator.getBattery();
-    const { level, charging, chargingtime, dischargingtime } = battery;
-
-    return {
-      batteryLevel: level,
-      lowPowerMode: false,
-      batteryState: level === 1 ? 'full' : charging ? 'charging' : 'unplugged',
-      chargingtime,
-      dischargingtime,
-    };
+    
+    return _readPowerState(battery);
   }
   return {};
 }
+
 export const getPowerStateSync = () => {
   return powerState;
 }
-

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -2,70 +2,58 @@ import { NativeEventEmitter, NativeModules } from 'react-native';
 
 const deviceInfoEmitter = new NativeEventEmitter(NativeModules.RNDeviceInfo);
 
-let isBatteryCharging = false,
+let batteryCharging = false,
   batteryLevel = -1,
   powerState = {};
 
-const getMaxMemorySync = () => {
+export const getMaxMemorySync = () => {
   if (window.performance && window.performance.memory) {
     return window.performance.memory.jsHeapSizeLimit;
   }
   return -1;
 };
 
-const getInstallReferrerSync = () => {
+export const getInstallReferrerSync = () => {
   return document.referrer;
 };
 
-const isAirplaneModeSync = () => {
+export const isAirplaneModeSync = () => {
   return !!navigator.onLine;
 };
 
-const getUserAgentSync = () => {
+export const getUserAgentSync = () => {
   return window.navigator.userAgent;
 };
 
-const isLocationEnabledSync = () => {
+export const isLocationEnabledSync = () => {
   return !!navigator.geolocation;
 };
 
-const getTotalMemorySync = () => {
+export const getTotalMemorySync = () => {
   if (navigator.deviceMemory) {
     return navigator.deviceMemory * 1000000000;
   }
   return -1;
 };
 
-const getUsedMemorySync = () => {
+export const getUsedMemorySync = () => {
   if (window.performance && window.performance.memory) {
     return window.performance.memory.usedJSHeapSize;
   }
   return -1;
 };
 
-const getPowerState = (battery) => {
-  const { level, charging, chargingtime, dischargingtime } = battery;
-
-  return {
-    batteryLevel: level,
-    lowPowerMode: false,
-    batteryState: level === 1 ? 'full' : charging ? 'charging' : 'unplugged',
-    chargingtime,
-    dischargingtime,
-  };
-};
-
 const init = async () => {
   if (navigator.getBattery) {
     const battery = await navigator.getBattery();
 
-    isBatteryCharging = battery.charging;
+    batteryCharging = battery.charging;
 
     battery.addEventListener('chargingchange', () => {
       const { charging } = battery;
 
-      isBatteryCharging = charging;
-      powerState = getPowerState(battery);
+      batteryCharging = charging;
+      powerState = getPowerStateSync(battery);
 
       deviceInfoEmitter.emit('RNDeviceInfo_powerStateDidChange', powerState);
     });
@@ -74,7 +62,7 @@ const init = async () => {
       const { level } = battery;
 
       batteryLevel = level;
-      powerState = getPowerState(battery);
+      powerState = getPowerStateSync(battery);
 
       deviceInfoEmitter.emit('RNDeviceInfo_batteryLevelDidChange', level);
       if (level < 0.2) {
@@ -112,107 +100,124 @@ init();
 /**
  * react-native-web empty polyfill.
  */
-module.exports = {
-  getInstallReferrer: async () => {
-    return getInstallReferrerSync();
-  },
-  getInstallReferrerSync,
-  getUserAgent: async () => {
-    return getUserAgentSync();
-  },
-  getUserAgentSync,
-  isBatteryCharging: async () => {
-    if (navigator.getBattery) {
-      const battery = await navigator.getBattery();
-      return battery.level;
-    }
-    return false;
-  },
-  isBatteryChargingSync: async () => {
-    return isBatteryCharging;
-  },
-  isCameraPresent: async () => {
-    if (navigator.getBattery) {
-      const devices = await navigator.mediaDevices.enumerateDevices();
-      return !!devices.find((d) => d.kind === 'videoinput');
-    }
-    return false;
-  },
-  isCameraPresentSync: async () => {
-    console.log(
-      '[react-native-device-info] isCameraPresentSync not supported - please use isCameraPresent'
-    );
-    return false;
-  },
-  getBatteryLevel: async () => {
-    if (navigator.getBattery) {
-      const battery = await navigator.getBattery();
-      return battery.level;
-    }
-    return -1;
-  },
-  getBatteryLevelSync: () => {
-    return batteryLevel;
-  },
-  isLocationEnabled: async () => {
-    return isLocationEnabledSync();
-  },
-  isLocationEnabledSync,
-  isAirplaneMode: async () => {
-    return isAirplaneModeSync();
-  },
-  isAirplaneModeSync,
-  getBaseOs: async () => {
-    return getBaseOsSync();
-  },
-  getBaseOsSync,
-  getTotalDiskCapacity: async () => {
-    if (navigator.storage && navigator.storage.estimate) {
-      const { quota } = await navigator.storage.estimate();
-      return quota;
-    }
-    return -1;
-  },
-  getTotalDiskCapacitySync: () => {
-    console.log(
-      '[react-native-device-info] getTotalDiskCapacitySync not supported - please use getTotalDiskCapacity'
-    );
-    return -1;
-  },
-  getFreeDiskStorage: async () => {
-    if (navigator.storage && navigator.storage.estimate) {
-      const { quota, usage } = await navigator.storage.estimate();
-      return quota - usage;
-    }
-    return -1;
-  },
-  getFreeDiskStorageSync: () => {
-    console.log(
-      '[react-native-device-info] getFreeDiskStorageSync not supported - please use getFreeDiskStorage'
-    );
-    return -1;
-  },
-  getMaxMemory: async () => {
-    return getMaxMemorySync();
-  },
-  getMaxMemorySync,
-  getUsedMemory: async () => {
-    return getUsedMemorySync();
-  },
-  getUsedMemorySync,
-  getTotalMemory: async () => {
-    return getTotalMemorySync();
-  },
-  getTotalMemorySync,
-  getPowerState: async () => {
-    if (navigator.getBattery) {
-      const battery = await navigator.getBattery();
 
-      return getPowerState(battery);
-    }
-    return {};
-  },
-  getPowerStateSync: () => {
-    return powerState;
-  },
-};
+export const getInstallReferrer = async () => {
+  return getInstallReferrerSync();
+}
+
+export const getUserAgent = async () => {
+  return getUserAgentSync();
+}
+
+export const isBatteryCharging = async () => {
+  if (navigator.getBattery) {
+    const battery = await navigator.getBattery();
+    return battery.level;
+  }
+  return false;
+}
+
+export const isBatteryChargingSync = () => {
+  return batteryCharging;
+}
+
+export const isCameraPresent = async () => {
+  if (navigator.getBattery) {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    return !!devices.find((d) => d.kind === 'videoinput');
+  }
+  return false;
+}
+
+export const isCameraPresentSync = () => {
+  console.log(
+    '[react-native-device-info] isCameraPresentSync not supported - please use isCameraPresent'
+  );
+  return false;
+}
+
+export const getBatteryLevel = async () => {
+  if (navigator.getBattery) {
+    const battery = await navigator.getBattery();
+    return battery.level;
+  }
+  return -1;
+}
+
+export const getBatteryLevelSync = () => {
+  return batteryLevel;
+}
+
+export const isLocationEnabled = async () => {
+  return isLocationEnabledSync();
+}
+
+export const isAirplaneMode = async () => {
+  return isAirplaneModeSync();
+}
+
+export const getBaseOs = async () => {
+  return getBaseOsSync();
+}
+
+export const getTotalDiskCapacity = async () => {
+  if (navigator.storage && navigator.storage.estimate) {
+    const { quota } = await navigator.storage.estimate();
+    return quota;
+  }
+  return -1;
+}
+
+export const getTotalDiskCapacitySync = () => {
+  console.log(
+    '[react-native-device-info] getTotalDiskCapacitySync not supported - please use getTotalDiskCapacity'
+  );
+  return -1;
+}
+
+export const getFreeDiskStorage = async () => {
+  if (navigator.storage && navigator.storage.estimate) {
+    const { quota, usage } = await navigator.storage.estimate();
+    return quota - usage;
+  }
+  return -1;
+}
+
+export const getFreeDiskStorageSync = () => {
+  console.log(
+    '[react-native-device-info] getFreeDiskStorageSync not supported - please use getFreeDiskStorage'
+  );
+  return -1;
+}
+
+export const getMaxMemory = async () => {
+  return getMaxMemorySync();
+}
+
+export const getUsedMemory = async () => {
+  return getUsedMemorySync();
+}
+
+export const getTotalMemory = async () => {
+  return getTotalMemorySync();
+}
+
+export const getPowerState = async () => {
+  if (navigator.getBattery) {
+    const battery = await navigator.getBattery();
+    const { level, charging, chargingtime, dischargingtime } = battery;
+
+    return {
+      batteryLevel: level,
+      lowPowerMode: false,
+      batteryState: level === 1 ? 'full' : charging ? 'charging' : 'unplugged',
+      chargingtime,
+      dischargingtime,
+    };
+  }
+  return {};
+}
+export const getPowerStateSync = () => {
+  return powerState;
+}
+


### PR DESCRIPTION
Fix issue: TypeError: https://github.com/react-native-community/react-native-device-info/issues/950

```
Quoting: https://github.com/webpack/webpack/issues/4039

You can mix require and export. You can't mix import and module.exports.
```

I simply replaced the module.exports syntax with 'export const' and it does fix the error.