### PR TITLE
'googlePlayServicesVersion' usage modified

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     if(firebaseIidVersion){
         implementation "com.google.firebase:firebase-iid:$firebaseIidVersion"
     }else{
-        def iidVersion = safeExtGet('googlePlayServicesIidVersion', safeExtGet('googlePlayServicesVersion', '17.0.0'))
+        def iidVersion = safeExtGet('googlePlayServicesIidVersion', '17.0.0')
         implementation "com.google.android.gms:play-services-iid:$iidVersion"
     }
 


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

break the strong bond between **googlePlayServicesIidVersion** and **googlePlayServicesVersion**

<!-- OR, if you're implementing a new feature: -->

Now in your main project's **build.gradle** file, you can use this;
```
ext {
    googlePlayServicesVersion   = "17.3.0"
}
```
While **googlePlayServicesIidVersion** will stay `17.0.0`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [X] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
