### PR TITLE
fix(ios): correctly calculate ios low battery threshold

### DIFF
--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -76,7 +76,7 @@ RCT_EXPORT_MODULE();
 {
     if ((self = [super init])) {
 #if !TARGET_OS_TV
-        _lowBatteryThreshold = 20;
+        _lowBatteryThreshold = 0.20;
         [[UIDevice currentDevice] setBatteryMonitoringEnabled:YES];
 
         [[NSNotificationCenter defaultCenter] addObserver:self


### PR DESCRIPTION
## Description

The battery value is 0.00 to 1.00 but the threshold was 0-100, so it
was an expectations mismatch.

Using threshold of 0.20 instead of 20 makes it work

Fixes #1038

I tested this on a real device since you can't simulate battery events on a simulator

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [x] I mentioned this change in `CHANGELOG.md`
* [x] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [x] I added a sample use of the API (`example/App.js`)
