### PR TITLE
fix(types): import LocationProviderInfo type, export result types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { useOnMount } from './internal/asyncHookWrappers';
 import devicesWithNotch from './internal/devicesWithNotch';
 import RNDeviceInfo from './internal/nativeInterface';
 import { DeviceInfoModule } from './internal/privateTypes';
-import { AsyncHookResult, DeviceType, PowerState } from './internal/types';
+import { AsyncHookResult, DeviceType, LocationProviderInfo, PowerState } from './internal/types';
 
 let uniqueId: string;
 export function getUniqueId() {
@@ -1334,6 +1334,8 @@ export function useHasSystemFeature(feature: string): AsyncHookResult<boolean> {
 export function useIsEmulator(): AsyncHookResult<boolean> {
   return useOnMount(isEmulator, false);
 }
+
+export { AsyncHookResult, DeviceType, LocationProviderInfo, PowerState };
 
 const deviceInfoModule: DeviceInfoModule = {
   getAndroidId,


### PR DESCRIPTION
Previously you knew you would get a PowerState object for instance, but
you could not actually use that type in your project code because it was
not exported

Additionally the LocationProviderInfo type was not even imported, and bob
seemed to handle it okay when generating the lib but it inlined a type requires to do it
which was silly

Fixes #1040 