### PR TITLE
fix: power connection and power save events were not triggering correctly

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -71,7 +71,8 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   private RNInstallReferrerClient installReferrerClient;
 
   private double mLastBatteryLevel = -1;
-  private String sLastBatteryState = "";
+  private String mLastBatteryState = "";
+  private boolean mLastPowerSaveState = false;
 
   private static String BATTERY_STATE = "batteryState";
   private static String BATTERY_LEVEL= "batteryLevel";
@@ -88,6 +89,11 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   public void initialize() {
     IntentFilter filter = new IntentFilter();
     filter.addAction(Intent.ACTION_BATTERY_CHANGED);
+    filter.addAction(Intent.ACTION_POWER_CONNECTED);
+    filter.addAction(Intent.ACTION_POWER_DISCONNECTED);
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+      filter.addAction(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED);
+    }
 
     receiver = new BroadcastReceiver() {
       @Override
@@ -100,10 +106,12 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
 
         String batteryState = powerState.getString(BATTERY_STATE);
         Double batteryLevel = powerState.getDouble(BATTERY_LEVEL);
+        Boolean powerSaveState = powerState.getBoolean(LOW_POWER_MODE);
 
-        if(!sLastBatteryState.equalsIgnoreCase(batteryState)) {
+        if(!mLastBatteryState.equalsIgnoreCase(batteryState) || mLastPowerSaveState != powerSaveState) {
           sendEvent(getReactApplicationContext(), "RNDeviceInfo_powerStateDidChange", batteryState);
-          sLastBatteryState = batteryState;
+          mLastBatteryState = batteryState;
+          mLastPowerSaveState = powerSaveState;
         }
 
         if(mLastBatteryLevel != batteryLevel) {

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -87,6 +87,10 @@ RCT_EXPORT_MODULE();
                                                  selector:@selector(powerStateDidChange:)
                                                      name:UIDeviceBatteryStateDidChangeNotification
                                                    object: nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(powerStateDidChange:)
+                                                     name:NSProcessInfoPowerStateDidChangeNotification
+                                                   object: nil];
 #endif
     }
 
@@ -584,7 +588,7 @@ RCT_EXPORT_METHOD(isPinOrFingerprintSet:(RCTPromiseResolveBlock)resolve rejecter
     }
 }
 
-- (void)powerStateDidChange:(NSNotification *)notification {
+- (void) powerStateDidChange:(NSNotification *)notification {
     if (!hasListeners) {
         return;
     }


### PR DESCRIPTION
## Description

Android was not listening to power connection events, now it is
Neither platform was triggering on low power mode, now they are


Fixes #1026 

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [x] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [x] I added a sample use of the API (`example/App.js`)
