### PR TITLE
Add Huawei P30 to devicesWithNotch list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Release Notes
 
+## 5.6.4
+
+- fix(android): fix missing Huawei P30 model name in devicesWithNotch.ts (@tronin)
+
 ## 5.6.3
 
 - fix(ios): fix WkWebView crash from parallel getUserAgent calls (#1050, thanks @RojoHub!)

--- a/src/internal/devicesWithNotch.ts
+++ b/src/internal/devicesWithNotch.ts
@@ -79,6 +79,10 @@ const devicesWithNotch: NotchDevice[] = [
   },
   {
     brand: 'Huawei',
+    model: 'ELE-L29', // P30
+  },
+  {
+    brand: 'Huawei',
     model: 'P30 Lite',
   },
   {


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes missing Huawei P30 model name in withNotch list

1. withNotch list has been updated

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅    |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a **device** for Huawei P30 and Android
* [x] I mentioned this change in `CHANGELOG.md`