### PR TITLE
Protect exported broadcast receiver with install packages permission.

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,8 +3,11 @@
     package="com.learnium.RNDeviceInfo">
 
   <application>
-    <receiver android:name="com.learnium.RNDeviceInfo.RNDeviceReceiver" android:enabled="true" android:exported="true"
-        tools:ignore="ExportedReceiver">
+    <receiver android:name="com.learnium.RNDeviceInfo.RNDeviceReceiver"
+        android:enabled="true"
+        android:exported="true"
+        tools:ignore="ExportedReceiver"
+        android:permission="android.permission.INSTALL_PACKAGES">
       <intent-filter>
         <action android:name="com.android.vending.INSTALL_REFERRER" />
       </intent-filter>


### PR DESCRIPTION
## Description

protects the exported broadcast receiver which listens for app installation intents with the INSTALL_PACKAGES permission to limit it's usage to broadcasters which are able to install packages (usually only the Play Store). This avoids warnings of scanners which check for publicly exported broadcast receivers and restricts that broadcast receiver as much as possible. With the permission set, the users has to explicitly grant an app the install packages permission for it to use the broadcast receiver. (Most users probably won't have any app other than the play store with that permission.) Unfortunately it will still show up as false-positive in MobSF, but with a longer explanation and note about permissions.

Fixes #452 and #554 

## Compatibility

This is android only and therefore doesn't require any changes on ios or windows.

| OS      | Implemented |
| ------- | :---------: |
| iOS     |   ❌     |
| Android |    ✅     |
| Windows |   ❌     |

## Checklist

<!-- Check completed item: [X] -->

Imo there is no need for sample code or README changes. It might deserve a mention in the changelog though.

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
