### PR TITLE
chore: add 2nd generation iPhone SE to device name list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 # Release Notes
 
-### Next:
- * Added the 2nd generation iPhone SE to the deviceNamesByCode list
+### 6.0.1
+ * Added the 2nd generation iPhone SE to the deviceNamesByCode list (#1068, thanks @steve-lorenz!)
 
 ## 6.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Release Notes
 
+### Next:
+ * Added the 2nd generation iPhone SE to the deviceNamesByCode list
+
 ## 6.0.0
 
 - BREAKING CHANGE(android, storage): Replace`getTotalDiskCapacity` and `getFreeDiskStorage` implementations, original

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -216,6 +216,7 @@ RCT_EXPORT_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
         @"iPhone12,1": @"iPhone 11",
         @"iPhone12,3": @"iPhone 11 Pro",
         @"iPhone12,5": @"iPhone 11 Pro Max",
+        @"iPhone12,8": @"iPhone SE", // (2nd Generation iPhone SE)
         @"iPad4,1": @"iPad Air", // 5th Generation iPad (iPad Air) - Wifi
         @"iPad4,2": @"iPad Air", // 5th Generation iPad (iPad Air) - Cellular
         @"iPad4,3": @"iPad Air", // 5th Generation iPad (iPad Air)


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description
I've added the 2nd generation iPhone SE to the list of available devices. This fixes a problem where it just returns "unknown" for this model.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android     |    ❌    |
| Windows     |     ❌     |


## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I mentioned this change in `CHANGELOG.md`
