### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/RNDeviceInfo.podspec
+++ b/RNDeviceInfo.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/react-native-community/react-native-device-info.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Latest Xcode 12 might fail to build when a library does not depend on `React-Core` directly hence this change is necessary for native modules on iOS. This change requires to React Native 0.60.2 or newer and it's not breaking change. For more details please check: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116

I have not tested this library with Xcode 12 yet, but most native modules fail so I'm submitting this PR as it's thas not change anything besides changing minimum RN version to 0.60.2.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ❌     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [ ] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
