### PR TITLE
[Documentation] getApiLevel returns -1 in iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ Gets the API level.
 
 ```js
 DeviceInfo.getApiLevel().then(apiLevel => {
-  // iOS: ?
+  // iOS: -1
   // Android: 25
   // Windows: ?
 });


### PR DESCRIPTION
## Description
Added `-1` as a return value for iOS for the `getAPILevel` function

The `?` in the documentation is a bit misleading. I thought I would get `null` or `undefined`. When I checked it was `-1`. I think it is good to document it in the API documentation if iOS has consistent return value for this function.

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
