### PR TITLE
fix(types): add returnType to getPowerState

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1066,7 +1066,7 @@ export function getBatteryLevelSync() {
   return -1;
 }
 
-export async function getPowerState() {
+export async function getPowerState(): Promise<PowerState | {}> {
   if (Platform.OS === 'ios' || Platform.OS === 'android' || Platform.OS === 'web') {
     return RNDeviceInfo.getPowerState();
   }


### PR DESCRIPTION
## Description
`getPowerState` returned a Promise that was always types as an empty object.
Correctly it should be the same returnType as `usePowerState` wrapped in a Promise => `Promise<PowerState | {}>`

Fixes #1081 