### PR TITLE
useManufacturer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1660,10 +1660,28 @@ const { loading, result } = useIsEmulator(); // { loading: true, result: false }
 <Text>{loading ? 'loading...' : result}</Text>;
 ```
 
+---
+
+### useManufacturer
+
+Gets the device manufacturer.
+
+#### Example
+
+```jsx
+import { useManufacturer } from 'react-native-device-info';
+
+const { loading, result } = useManufacturer(); // { loading: true, result: "Apple"}
+
+<Text>{loading ? 'loading...' : result}</Text>;
+```
+
 =======
+
 ## Native interoperatibily
 
 If you need to check for device type from the native side, you can use the following:
+
 ```java
 import com.learnium.resolver.DeviceTypeResolver
 

--- a/example/App.js
+++ b/example/App.js
@@ -26,6 +26,7 @@ import {
   usePowerState,
   useFirstInstallTime,
   useDeviceName,
+  useManufacturer,
   useHasSystemFeature,
   useIsEmulator,
 } from 'react-native-device-info';
@@ -36,6 +37,7 @@ const FunctionalComponent = () => {
   const powerState = usePowerState();
   const firstInstallTime = useFirstInstallTime();
   const deviceName = useDeviceName();
+  const manufacturer = useManufacturer();
   const hasSystemFeature = useHasSystemFeature('amazon.hardware.fire_tv');
   const isEmulator = useIsEmulator();
   const deviceJSON = {
@@ -44,6 +46,7 @@ const FunctionalComponent = () => {
     powerState,
     firstInstallTime,
     deviceName,
+    manufacturer,
     hasSystemFeature,
     isEmulator,
   };

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -154,4 +154,5 @@ declare module.exports: {
   useHasSystemFeature: (feature: string) => AsyncHookResult<boolean>,
   useIsEmulator: () => AsyncHookResult<boolean>,
   usePowerState: () => PowerState | {},
+  useManufacturer: () => AsyncHookResult<string>,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1379,6 +1379,10 @@ export function useIsEmulator(): AsyncHookResult<boolean> {
   return useOnMount(isEmulator, false);
 }
 
+export function useManufacturer(): AsyncHookResult<string> {
+  return useOnMount(getManufacturer, 'unknown');
+}
+
 export { AsyncHookResult, DeviceType, LocationProviderInfo, PowerState };
 
 const deviceInfoModule: DeviceInfoModule = {
@@ -1513,6 +1517,7 @@ const deviceInfoModule: DeviceInfoModule = {
   useHasSystemFeature,
   useIsEmulator,
   usePowerState,
+  useManufacturer,
 };
 
 export default deviceInfoModule;

--- a/src/internal/privateTypes.ts
+++ b/src/internal/privateTypes.ts
@@ -177,4 +177,5 @@ export interface DeviceInfoModule extends ExposedNativeMethods {
   useHasSystemFeature: (feature: string) => AsyncHookResult<boolean>;
   useIsEmulator: () => AsyncHookResult<boolean>;
   usePowerState: () => PowerState | {};
+  useManufacturer: () => AsyncHookResult<string>;
 }


### PR DESCRIPTION
Added `useManufacturer()` that wraps the async function, `getManufacturer()`, in a hook.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅ ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [ ] I have tested this on a device/simulator for each compatible OS
  * I wasn't able to confirm on a Windows box, but was able to do so on iOS and Android. I assume it would work because the core, `getManufacturer()`, is marked as being able to work on Windows.
* [x] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [x] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [x] I added a sample use of the API (`example/App.js`)

