### PR TITLE
adding useIsHeadphonesConnected

### DIFF
--- a/README.md
+++ b/README.md
@@ -1676,6 +1676,24 @@ const { loading, result } = useManufacturer(); // { loading: true, result: "Appl
 <Text>{loading ? 'loading...' : result}</Text>;
 ```
 
+---
+
+### useIsHeadphonesConnected
+
+Tells if the device is connected to wired headset or bluetooth headphones.
+
+This hook subscribes to the event, `RNDeviceInfo_headphoneConnectionDidChange` , and updates the `result` field accordingly.
+
+#### Example
+
+```jsx
+import { useIsHeadphonesConnected } from 'react-native-device-info';
+
+const { loading, result } = useIsHeadphonesConnected(); // { loading: true, result: false}
+
+<Text>{loading ? 'loading...' : result}</Text>;
+```
+
 =======
 
 ## Native interoperatibily

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -68,6 +68,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   private final DeviceTypeResolver deviceTypeResolver;
   private final DeviceIdResolver deviceIdResolver;
   private BroadcastReceiver receiver;
+  private BroadcastReceiver headphoneConnectionReceiver;
   private RNInstallReferrerClient installReferrerClient;
 
   private double mLastBatteryLevel = -1;
@@ -127,12 +128,30 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     };
 
     getReactApplicationContext().registerReceiver(receiver, filter);
+    initializeHeadphoneConnectionReceiver();
+  }
+
+  private void initializeHeadphoneConnectionReceiver() {
+    IntentFilter filter = new IntentFilter();
+    filter.addAction(AudioManager.ACTION_HEADSET_PLUG);
+    filter.addAction(AudioManager.ACTION_SCO_AUDIO_STATE_UPDATED);
+
+    headphoneConnectionReceiver = new BroadcastReceiver() {
+      @Override
+      public void onReceive(Context context, Intent intent) {
+        boolean isConnected = isHeadphonesConnectedSync();
+        sendEvent(getReactApplicationContext(), "RNDeviceInfo_headphoneConnectionDidChange", isConnected);
+      }
+    };
+
+    getReactApplicationContext().registerReceiver(headphoneConnectionReceiver, filter);
   }
 
 
   @Override
   public void onCatalystInstanceDestroy() {
     getReactApplicationContext().unregisterReceiver(receiver);
+    getReactApplicationContext().unregisterReceiver(headphoneConnectionReceiver);
   }
 
 

--- a/example/App.js
+++ b/example/App.js
@@ -29,6 +29,7 @@ import {
   useManufacturer,
   useHasSystemFeature,
   useIsEmulator,
+  useIsHeadphonesConnected,
 } from 'react-native-device-info';
 
 const FunctionalComponent = () => {
@@ -40,6 +41,7 @@ const FunctionalComponent = () => {
   const manufacturer = useManufacturer();
   const hasSystemFeature = useHasSystemFeature('amazon.hardware.fire_tv');
   const isEmulator = useIsEmulator();
+  const isHeadphonesConnected = useIsHeadphonesConnected();
   const deviceJSON = {
     batteryLevel,
     batteryLevelIsLow,
@@ -49,6 +51,7 @@ const FunctionalComponent = () => {
     manufacturer,
     hasSystemFeature,
     isEmulator,
+    isHeadphonesConnected,
   };
 
   return (

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -49,7 +49,7 @@ RCT_EXPORT_MODULE();
 
 - (NSArray<NSString *> *)supportedEvents
 {
-    return @[@"RNDeviceInfo_batteryLevelDidChange", @"RNDeviceInfo_batteryLevelIsLow", @"RNDeviceInfo_powerStateDidChange"];
+    return @[@"RNDeviceInfo_batteryLevelDidChange", @"RNDeviceInfo_batteryLevelIsLow", @"RNDeviceInfo_powerStateDidChange", @"RNDeviceInfo_headphoneConnectionDidChange"];
 }
 
 - (NSDictionary *)constantsToExport {
@@ -88,6 +88,10 @@ RCT_EXPORT_MODULE();
                                                  selector:@selector(powerStateDidChange:)
                                                      name:NSProcessInfoPowerStateDidChangeNotification
                                                    object: nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(headphoneConnectionDidChange:)
+                                                     name:AVAudioSessionRouteChangeNotification
+                                                   object: [AVAudioSession sharedInstance]];
 #endif
     }
 
@@ -591,6 +595,14 @@ RCT_EXPORT_METHOD(isPinOrFingerprintSet:(RCTPromiseResolveBlock)resolve rejecter
         return;
     }
     [self sendEventWithName:@"RNDeviceInfo_powerStateDidChange" body:self.powerState];
+}
+
+- (void) headphoneConnectionDidChange:(NSNotification *)notification {
+    if (!hasListeners) {
+        return;
+    }
+    BOOL isConnected = [self isHeadphonesConnected];
+    [self sendEventWithName:@"RNDeviceInfo_headphoneConnectionDidChange" body:[NSNumber numberWithBool:isConnected]];
 }
 
 - (NSDictionary *) powerState {

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -155,4 +155,5 @@ declare module.exports: {
   useIsEmulator: () => AsyncHookResult<boolean>,
   usePowerState: () => PowerState | {},
   useManufacturer: () => AsyncHookResult<string>,
+  useIsHeadphonesConnected: () => AsyncHookResult<boolean>,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Dimensions, NativeEventEmitter, NativeModules, Platform } from 'react-native';
-import { useOnMount } from './internal/asyncHookWrappers';
+import { useOnEvent, useOnMount } from './internal/asyncHookWrappers';
 import devicesWithNotch from './internal/devicesWithNotch';
 import RNDeviceInfo from './internal/nativeInterface';
 import { DeviceInfoModule } from './internal/privateTypes';
@@ -1362,6 +1362,10 @@ export function usePowerState(): PowerState | {} {
   return powerState;
 }
 
+export function useIsHeadphonesConnected(): AsyncHookResult<boolean> {
+  return useOnEvent('RNDeviceInfo_headphoneConnectionDidChange', isHeadphonesConnected, false);
+}
+
 export function useFirstInstallTime(): AsyncHookResult<number> {
   return useOnMount(getFirstInstallTime, -1);
 }
@@ -1518,6 +1522,7 @@ const deviceInfoModule: DeviceInfoModule = {
   useIsEmulator,
   usePowerState,
   useManufacturer,
+  useIsHeadphonesConnected,
 };
 
 export default deviceInfoModule;

--- a/src/internal/asyncHookWrappers.ts
+++ b/src/internal/asyncHookWrappers.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-
+import { NativeEventEmitter, NativeModules } from 'react-native';
 import { AsyncHookResult } from './types';
 
 /**
@@ -24,4 +24,36 @@ export function useOnMount<T>(asyncGetter: () => Promise<T>, initialResult: T): 
   }, [asyncGetter]);
 
   return response;
+}
+
+const deviceInfoEmitter = new NativeEventEmitter(NativeModules.RNDeviceInfo);
+
+/**
+ * simple hook wrapper for handling events
+ * @param eventName
+ * @param initialValueAsyncGetter
+ * @param defaultValue
+ */
+export function useOnEvent<T>(
+  eventName: string,
+  initialValueAsyncGetter: () => Promise<T>,
+  defaultValue: T
+): AsyncHookResult<T> {
+  const { loading, result: initialResult } = useOnMount(initialValueAsyncGetter, defaultValue);
+  const [result, setResult] = useState<T>(defaultValue);
+
+  // sets the result to what the intial value is on mount
+  useEffect(() => {
+    setResult(initialResult);
+  }, [initialResult]);
+
+  // - set up the event listener to set the result
+  // - set up the clean up function to remove subscription on unmount
+  useEffect(() => {
+    const subscription = deviceInfoEmitter.addListener(eventName, setResult);
+    return () => subscription.remove();
+  }, []);
+
+  // loading will only be true while getting the inital value. After that, it will always be false, but a new result may occur
+  return { loading, result };
 }

--- a/src/internal/privateTypes.ts
+++ b/src/internal/privateTypes.ts
@@ -178,4 +178,5 @@ export interface DeviceInfoModule extends ExposedNativeMethods {
   useIsEmulator: () => AsyncHookResult<boolean>;
   usePowerState: () => PowerState | {};
   useManufacturer: () => AsyncHookResult<string>;
+  useIsHeadphonesConnected: () => AsyncHookResult<boolean>;
 }


### PR DESCRIPTION
#569 
 Description

Fixes #1013

- Added hook, `useIsHeadphonesConnected()` , that tells if headphones are connected to the device. 
- Added a new event, `RNDeviceInfo_headphoneConnectionDidChange`,  that is fired by iOS and Android
- Added a convenience hook, `useOnEvent` , that
  - is used by `useIsHeadphonesConnected`
  - can be used to update existing event hooks to DRY them up
  - can help 'simplify' future event hooks



## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅    |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [X] I have tested this on a device/simulator for each compatible OS
* [X] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [X] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [X] I added a sample use of the API (`example/App.js`)


### TL;DR

![use-is-headphones-connected mov](https://user-images.githubusercontent.com/4561856/95009867-215f0800-05f3-11eb-95bb-95631a30676d.gif)
